### PR TITLE
Add missing bazel-remote-apis.diff

### DIFF
--- a/patches/gazelle/bazel-remote-apis.diff
+++ b/patches/gazelle/bazel-remote-apis.diff
@@ -1,0 +1,10 @@
+diff --git MODULE.bazel MODULE.bazel
+index d821962..19efede 100644
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -75,3 +75,5 @@ single_version_override(
+     patch_strip = 1,
+     patches = ["//third_party/patches:rules_go.patch"],
+ )
++
++bazel_dep(name = "bazel_remote_apis", version = "0.0.0")

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_go//go:def.bzl", "go_library")
 go_library(
     name = "tools",
     srcs = ["deps.go"],
-    importpath = "github.com/buildbarn/bb-storage/tools",
+    importpath = "github.com/buildbarn/bb-portal/tools",
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
I missed this file when making #3. For whatever reason, it doesn't show up as an untracked file.
Gazelle also corrected a wrong importpath, which I'm adding here to avoid creating a second PR just for that small change.