### PR TITLE
Regenerate workflows and enable CI

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -37,11 +37,11 @@
             },
             {
                "name": "Protobuf generation",
-               "run": "find . bazel-bin/pkg/proto -name '*.pb.go' -delete || true\nbazel build $(bazel query --output=label 'kind(\"go_proto_library\", //...)')\nfind bazel-bin/pkg/proto -name '*.pb.go' | while read f; do\n  cat $f > $(echo $f | sed -e 's|.*/pkg/proto/|pkg/proto/|')\ndone\n"
+               "run": "if [ -d bazel-bin/pkg/proto ]; then\n  find . bazel-bin/pkg/proto -name '*.pb.go' -delete || true\n  bazel build $(bazel query --output=label 'kind(\"go_proto_library\", //...)')\n  find bazel-bin/pkg/proto -name '*.pb.go' | while read f; do\n    cat $f > $(echo $f | sed -e 's|.*/pkg/proto/|pkg/proto/|')\n  done\nfi\n"
             },
             {
                "name": "Embedded asset generation",
-               "run": "bazel build $(git grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |//\\1:|' | sort -u)\ngit grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |\\1/|' | while read o; do\n  if [ -e \"bazel-bin/$o\" ]; then\n    rm -rf \"$o\"\n    cp -r \"bazel-bin/$o\" \"$o\"\n    find \"$o\" -type f -exec chmod -x {} +\n  fi\ndone\n"
+               "run": "bazel build $(git grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |//\\1:|; s|\"||g; s| .*||' | sort -u)\ngit grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |\\1/|' | while read o; do\n  if [ -e \"bazel-bin/$o\" ]; then\n    rm -rf \"$o\"\n    cp -r \"bazel-bin/$o\" \"$o\"\n    find \"$o\" -type f -exec chmod -x {} +\n  fi\ndone\n"
             },
             {
                "name": "Test style conformance",
@@ -197,6 +197,7 @@
    "on": {
       "push": {
          "branches": [
+            "main",
             "master"
          ]
       }

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -37,11 +37,11 @@
             },
             {
                "name": "Protobuf generation",
-               "run": "find . bazel-bin/pkg/proto -name '*.pb.go' -delete || true\nbazel build $(bazel query --output=label 'kind(\"go_proto_library\", //...)')\nfind bazel-bin/pkg/proto -name '*.pb.go' | while read f; do\n  cat $f > $(echo $f | sed -e 's|.*/pkg/proto/|pkg/proto/|')\ndone\n"
+               "run": "if [ -d bazel-bin/pkg/proto ]; then\n  find . bazel-bin/pkg/proto -name '*.pb.go' -delete || true\n  bazel build $(bazel query --output=label 'kind(\"go_proto_library\", //...)')\n  find bazel-bin/pkg/proto -name '*.pb.go' | while read f; do\n    cat $f > $(echo $f | sed -e 's|.*/pkg/proto/|pkg/proto/|')\n  done\nfi\n"
             },
             {
                "name": "Embedded asset generation",
-               "run": "bazel build $(git grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |//\\1:|' | sort -u)\ngit grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |\\1/|' | while read o; do\n  if [ -e \"bazel-bin/$o\" ]; then\n    rm -rf \"$o\"\n    cp -r \"bazel-bin/$o\" \"$o\"\n    find \"$o\" -type f -exec chmod -x {} +\n  fi\ndone\n"
+               "run": "bazel build $(git grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |//\\1:|; s|\"||g; s| .*||' | sort -u)\ngit grep '^[[:space:]]*//go:embed ' | sed -e 's|\\(.*\\)/.*//go:embed |\\1/|' | while read o; do\n  if [ -e \"bazel-bin/$o\" ]; then\n    rm -rf \"$o\"\n    cp -r \"bazel-bin/$o\" \"$o\"\n    find \"$o\" -type f -exec chmod -x {} +\n  fi\ndone\n"
             },
             {
                "name": "Test style conformance",
@@ -90,6 +90,7 @@
    "on": {
       "pull_request": {
          "branches": [
+            "main",
             "master"
          ]
       }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ git_override(
 
 git_override(
     module_name = "com_github_buildbarn_bb_storage",
-    commit = "256ec6c483a05f1aeefff6fc57a2044f746c5a08",
+    commit = "8abbcfab01bcde294b20c2070baba9fd242bab7f",
     remote = "https://github.com/buildbarn/bb-storage.git",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4666,6 +4666,81 @@
           ]
         ]
       }
+    },
+    "@@toolchains_llvm~//toolchain/extensions:llvm.bzl%llvm": {
+      "general": {
+        "bzlTransitiveDigest": "y9h5L2NtWbogyWSOJgqnUaU50MTPWAW+waelXSirMVg=",
+        "usagesDigest": "/+NEYJ20jcTtUbFN43e594RxhN3RYVQozRDp0gRFigY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm_toolchain": {
+            "bzlFile": "@@toolchains_llvm~//toolchain:rules.bzl",
+            "ruleClassName": "toolchain",
+            "attributes": {
+              "absolute_paths": false,
+              "archive_flags": {},
+              "compile_flags": {},
+              "coverage_compile_flags": {},
+              "coverage_link_flags": {},
+              "cxx_builtin_include_directories": {},
+              "cxx_flags": {},
+              "cxx_standard": {},
+              "dbg_compile_flags": {},
+              "exec_arch": "",
+              "exec_os": "",
+              "link_flags": {},
+              "link_libs": {},
+              "llvm_versions": {
+                "": "14.0.0"
+              },
+              "opt_compile_flags": {},
+              "opt_link_flags": {},
+              "stdlib": {},
+              "target_settings": {},
+              "unfiltered_compile_flags": {},
+              "toolchain_roots": {},
+              "sysroot": {}
+            }
+          },
+          "llvm_toolchain_llvm": {
+            "bzlFile": "@@toolchains_llvm~//toolchain:rules.bzl",
+            "ruleClassName": "llvm",
+            "attributes": {
+              "alternative_llvm_sources": [],
+              "auth_patterns": {},
+              "distribution": "auto",
+              "exec_arch": "",
+              "exec_os": "",
+              "llvm_mirror": "",
+              "llvm_version": "14.0.0",
+              "llvm_versions": {},
+              "netrc": "",
+              "sha256": {},
+              "strip_prefix": {},
+              "urls": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "toolchains_llvm~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "toolchains_llvm~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "toolchains_llvm~",
+            "toolchains_llvm",
+            "toolchains_llvm~"
+          ]
+        ]
+      }
     }
   }
 }

--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	readHeaderTimeout = 3 * time.Second
-	folderPermission  = 0750
+	folderPermission  = 0o750
 )
 
 var (

--- a/internal/api/grpc/bes/bes.go
+++ b/internal/api/grpc/bes/bes.go
@@ -60,7 +60,7 @@ func (b BES) PublishBuildToolEventStream(stream build.PublishBuildEvent_PublishB
 			slog.ErrorContext(stream.Context(), "Recv failed", "err", err)
 			return err
 		}
-		//slog.InfoContext(stream.Context(), "Received ordered build event", "event", protojson.Format(req))
+		// slog.InfoContext(stream.Context(), "Received ordered build event", "event", protojson.Format(req))
 
 		if streamID == nil {
 			streamID = req.GetOrderedBuildEvent().GetStreamId()

--- a/internal/graphql/custom.resolvers.go
+++ b/internal/graphql/custom.resolvers.go
@@ -191,6 +191,8 @@ func (r *Resolver) BlobReference() BlobReferenceResolver { return &blobReference
 // TestResult returns TestResultResolver implementation.
 func (r *Resolver) TestResult() TestResultResolver { return &testResultResolver{r} }
 
-type actionProblemResolver struct{ *Resolver }
-type blobReferenceResolver struct{ *Resolver }
-type testResultResolver struct{ *Resolver }
+type (
+	actionProblemResolver struct{ *Resolver }
+	blobReferenceResolver struct{ *Resolver }
+	testResultResolver    struct{ *Resolver }
+)

--- a/internal/graphql/ent.resolvers.go
+++ b/internal/graphql/ent.resolvers.go
@@ -346,14 +346,16 @@ func (r *Resolver) EventFileWhereInput() EventFileWhereInputResolver {
 	return &eventFileWhereInputResolver{r}
 }
 
-type bazelInvocationResolver struct{ *Resolver }
-type bazelInvocationProblemResolver struct{ *Resolver }
-type blobResolver struct{ *Resolver }
-type buildResolver struct{ *Resolver }
-type eventFileResolver struct{ *Resolver }
-type queryResolver struct{ *Resolver }
-type bazelInvocationProblemWhereInputResolver struct{ *Resolver }
-type bazelInvocationWhereInputResolver struct{ *Resolver }
-type blobWhereInputResolver struct{ *Resolver }
-type buildWhereInputResolver struct{ *Resolver }
-type eventFileWhereInputResolver struct{ *Resolver }
+type (
+	bazelInvocationResolver                  struct{ *Resolver }
+	bazelInvocationProblemResolver           struct{ *Resolver }
+	blobResolver                             struct{ *Resolver }
+	buildResolver                            struct{ *Resolver }
+	eventFileResolver                        struct{ *Resolver }
+	queryResolver                            struct{ *Resolver }
+	bazelInvocationProblemWhereInputResolver struct{ *Resolver }
+	bazelInvocationWhereInputResolver        struct{ *Resolver }
+	blobWhereInputResolver                   struct{ *Resolver }
+	buildWhereInputResolver                  struct{ *Resolver }
+	eventFileWhereInputResolver              struct{ *Resolver }
+)

--- a/internal/graphql/graphql_helpers_test.go
+++ b/internal/graphql/graphql_helpers_test.go
@@ -18,9 +18,7 @@ import (
 	"github.com/buildbarn/bb-portal/internal/graphql"
 )
 
-var (
-	update = flag.Bool("update-golden", false, "update golden (.out.json) files")
-)
+var update = flag.Bool("update-golden", false, "update golden (.out.json) files")
 
 type setupFuncEnt func(ctx context.Context, client *ent.Client)
 
@@ -68,7 +66,7 @@ func newMockServer(t *testing.T, entDataSource string) *mockServer {
 		Server: server,
 		URL:    server.URL,
 		ctx:    ctx,
-		//ctrl:   ctrl,
+		// ctrl:   ctrl,
 		client: client,
 	}
 	t.Cleanup(func() {

--- a/pkg/events/reader.go
+++ b/pkg/events/reader.go
@@ -204,7 +204,6 @@ func (it *BuildEventIterator) Next() (*BuildEvent, error) {
 	}
 
 	lineBytes, err := it.scanner.Bytes(), it.scanner.Err()
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to read a line from build event file: %w", err)
 	}

--- a/pkg/processing/archive.go
+++ b/pkg/processing/archive.go
@@ -17,9 +17,7 @@ import (
 	"github.com/buildbarn/bb-portal/pkg/summary/detectors"
 )
 
-var (
-	errNoArchiver = errors.New("no archiver registered")
-)
+var errNoArchiver = errors.New("no archiver registered")
 
 type BlobArchiver interface {
 	ArchiveBlob(ctx context.Context, blobURI detectors.BlobURI) ent.Blob

--- a/pkg/processing/summarize.go
+++ b/pkg/processing/summarize.go
@@ -6,8 +6,7 @@ import (
 	"github.com/buildbarn/bb-portal/pkg/summary"
 )
 
-type SummarizeActor struct {
-}
+type SummarizeActor struct{}
 
 func (SummarizeActor) Summarize(ctx context.Context, eventFileURL string) (*summary.Summary, error) {
 	return summary.Summarize(ctx, eventFileURL)

--- a/pkg/testkit/golden.go
+++ b/pkg/testkit/golden.go
@@ -26,14 +26,14 @@ type CompareOptions struct {
 // goldenDir defines the directory that holds golden files.
 // testName is the name of the test, which will be sluggified to determine the golden file to use
 // update is a flag that determines if we should update the golden file.
-func CheckAgainstGoldenFile(t *testing.T, got map[string]interface{}, goldenDir string, testName string, update *bool, opts *CompareOptions) {
+func CheckAgainstGoldenFile(t *testing.T, got map[string]interface{}, goldenDir, testName string, update *bool, opts *CompareOptions) {
 	testSlug := strings.ReplaceAll(testName, " ", "-")
 	golden := filepath.Join(goldenDir, fmt.Sprintf("%s.golden.json", testSlug))
 
 	if *update {
 		dir := filepath.Dir(golden)
 		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
-		require.NoError(t, os.WriteFile(golden, prettyJSON(got), 0640))
+		require.NoError(t, os.WriteFile(golden, prettyJSON(got), 0o640))
 	}
 
 	// get golden file
@@ -94,6 +94,7 @@ func replaceTimes(str string) (string, error) {
 
 	return lastModifiedPattern.ReplaceAllString(res, `Mon, 01 Jan 0001 00:00:00 GMT`), nil
 }
+
 func prettyJSON(data interface{}) []byte {
 	jsonText, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {

--- a/pkg/testkit/graphql.go
+++ b/pkg/testkit/graphql.go
@@ -27,7 +27,7 @@ type QueryRegistry struct {
 	entries map[string]*registryEntry
 }
 
-func LoadQueryRegistry(t *testing.T, queryDir string, consumerContractFile string) *QueryRegistry {
+func LoadQueryRegistry(t *testing.T, queryDir, consumerContractFile string) *QueryRegistry {
 	reg := QueryRegistry{entries: make(map[string]*registryEntry)}
 
 	queryFiles, err := os.ReadDir(queryDir)
@@ -96,8 +96,10 @@ type ConsumerContract struct {
 	Operations  map[string]Operation `yaml:"operations"`
 }
 
-type Document string
-type Variables map[string]interface{}
+type (
+	Document  string
+	Variables map[string]interface{}
+)
 
 type Operation struct {
 	Document  Document `yaml:"document"`

--- a/pkg/uuidgql/uuidgql.go
+++ b/pkg/uuidgql/uuidgql.go
@@ -10,9 +10,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var (
-	errExpectedString = errors.New("expected string")
-)
+var errExpectedString = errors.New("expected string")
 
 func MarshalUUID(u uuid.UUID) graphql.Marshaler {
 	return graphql.WriterFunc(func(w io.Writer) {


### PR DESCRIPTION
The workflow generation library in bb-storage needed some changes to get CI working. Also needed to update the lockfile and run gofumpt.

There are a lot of golint errors, which make this PR fail CI, that we’ll fix later