### PR TITLE
Build and publish frontend Docker container

### DIFF
--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -1,0 +1,24 @@
+name: Publish frontend
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  publish:
+    name: Publish frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Install Docker credentials
+        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u $ --password-stdin
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ghcr.io/buildbarn/bb-portal-frontend:${{ github.sha }}

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -1,0 +1,20 @@
+name: Build frontend
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  publish:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: frontend
+          file: ./frontend/Dockerfile
+          push: false
+          tags: ghcr.io/buildbarn/bb-portal-frontend:${{ github.sha }}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:22-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable pnpm && pnpm i --frozen-lockfile
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN corepack enable pnpm && pnpm run build
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]


### PR DESCRIPTION
This adds a Dockerfile for the frontend, and sets up build/publish for that image. We should see if we can build it with Bazel, but I ran into some trouble and would prefer not to postpone getting this published while I work out the details.