### PR TITLE
Fix card header flow

### DIFF
--- a/frontend/src/components/PortalCard/index.module.css
+++ b/frontend/src/components/PortalCard/index.module.css
@@ -1,8 +1,8 @@
-.header {
-  display: inline-block;
+.portalCardHeader {
   align-items: center;
   white-space: nowrap;
   line-height: 32px;
+
 }
 
 .title a:not(:hover) {

--- a/frontend/src/components/PortalCard/index.module.css
+++ b/frontend/src/components/PortalCard/index.module.css
@@ -1,8 +1,7 @@
-.portalCardHeader {
+.header {
   align-items: center;
   white-space: nowrap;
   line-height: 32px;
-
 }
 
 .title a:not(:hover) {


### PR DESCRIPTION
best guess, #13 changed some small CSS dependency some where and all of the sudden [this](https://github.com/buildbarn/bb-portal/compare/main...fix-card-header-flow#diff-0ff55aa1d51e8126f23cc1a7307ef7d3951b644a5c4118e45688c3328de805f1L2) line of css started getting applied, (where it was seemingly previously being ignored, possibly by something w/a higher priority... idk for sure).  Removing it fixes the flow and alignment of those card header elements..