### PR TITLE
Frontend Runtime Environtment Variables

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "@apollo/client": "^3.10.2",
     "@apollo/experimental-nextjs-app-support": "^0.10.0",
     "ansi_up": "^6.0.2",
-    "antd": "^5.17.4",
+    "antd": "^5.21.3",
     "dayjs": "^1.11.11",
     "framer-motion": "^11.1.9",
     "graphql": "^16.8.1",
@@ -27,9 +27,9 @@
     "next": "14.2.3",
     "next-runtime-env": "^3.2.2",
     "rc-menu": "^9.13.0",
-    "react": "^18",
+    "react": "^18.3.1",
     "react-countup": "^6.5.3",
-    "react-dom": "^18",
+    "react-dom": "^18.3.1",
     "recharts": "^2.12.7",
     "uuid": "^9.0.1",
     "zod": "^3.23.8"
@@ -39,14 +39,14 @@
     "@graphql-codegen/client-preset": "^4.2.5",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@types/lodash": "^4.17.4",
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/node": "^20.12.8",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.0",
     "@types/uuid": "^9.0.8",
     "env-cmd": "^10.1.0",
-    "eslint": "^8",
+    "eslint": "^8.57.0",
     "eslint-config-next": "14.2.3",
-    "typescript": "^5"
+    "typescript": "^5.4.5"
   },
   "pnpm": {
     "onlyBuiltDependencies": []

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "linkify-html": "^4.1.3",
     "lodash": "^4.17.21",
     "next": "14.2.3",
+    "next-runtime-env": "^3.2.2",
     "rc-menu": "^9.13.0",
     "react": "^18",
     "react-countup": "^6.5.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       antd:
-        specifier: ^5.17.4
+        specifier: ^5.21.3
         version: 5.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       dayjs:
         specifier: ^1.11.11
@@ -54,13 +54,13 @@ importers:
         specifier: ^9.13.0
         version: 9.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
-        specifier: ^18
+        specifier: ^18.3.1
         version: 18.3.1
       react-countup:
         specifier: ^6.5.3
         version: 6.5.3(react@18.3.1)
       react-dom:
-        specifier: ^18
+        specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       recharts:
         specifier: ^2.12.7
@@ -85,13 +85,13 @@ importers:
         specifier: ^4.17.4
         version: 4.17.4
       '@types/node':
-        specifier: ^20
+        specifier: ^20.12.8
         version: 20.12.8
       '@types/react':
-        specifier: ^18
+        specifier: ^18.3.1
         version: 18.3.1
       '@types/react-dom':
-        specifier: ^18
+        specifier: ^18.3.0
         version: 18.3.0
       '@types/uuid':
         specifier: ^9.0.8
@@ -100,13 +100,13 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       eslint:
-        specifier: ^8
+        specifier: ^8.57.0
         version: 8.57.0
       eslint-config-next:
         specifier: 14.2.3
         version: 14.2.3(eslint@8.57.0)(typescript@5.4.5)
       typescript:
-        specifier: ^5
+        specifier: ^5.4.5
         version: 5.4.5
 
 packages:
@@ -1247,8 +1247,8 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001615:
-    resolution: {integrity: sha512-1IpazM5G3r38meiae0bHRnPhz+CBQ3ZLqbQMtrg+AsTPKAXgW38JNsXkyZ+v8waCsDmPq87lmfun5Q2AGysNEQ==}
+  caniuse-lite@1.0.30001668:
+    resolution: {integrity: sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -4960,7 +4960,7 @@ snapshots:
 
   browserslist@4.23.0:
     dependencies:
-      caniuse-lite: 1.0.30001615
+      caniuse-lite: 1.0.30001668
       electron-to-chromium: 1.4.757
       node-releases: 2.0.14
       update-browserslist-db: 1.0.15(browserslist@4.23.0)
@@ -4995,7 +4995,7 @@ snapshots:
 
   camelcase@5.3.1: {}
 
-  caniuse-lite@1.0.30001615: {}
+  caniuse-lite@1.0.30001668: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -6248,7 +6248,7 @@ snapshots:
       '@next/env': 14.2.3
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001615
+      caniuse-lite: 1.0.30001668
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       next:
         specifier: 14.2.3
         version: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-runtime-env:
+        specifier: ^3.2.2
+        version: 3.2.2(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       rc-menu:
         specifier: ^9.13.0
         version: 9.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2342,6 +2345,12 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-runtime-env@3.2.2:
+    resolution: {integrity: sha512-S5S6NxIf3XeaVc9fLBN2L5Jzu+6dLYCXeOaPQa1RzKRYlG2BBayxXOj6A4VsciocyNkJMazW1VAibtbb1/ZjAw==}
+    peerDependencies:
+      next: ^14
+      react: ^18
 
   next@14.2.3:
     resolution: {integrity: sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==}
@@ -5391,7 +5400,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -5414,8 +5423,8 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -5426,7 +5435,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5437,7 +5446,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -5447,7 +5456,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6228,6 +6237,11 @@ snapshots:
   nanoid@3.3.7: {}
 
   natural-compare@1.4.0: {}
+
+  next-runtime-env@3.2.2(next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      next: 14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   next@14.2.3(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -12,6 +12,7 @@ import light from '@/theme/light';
 import Dynamic from '@/components/Dynamic';
 import { ApolloWrapper } from '@/components/ApolloWrapper';
 import parseStringBoolean from '@/utils/storage';
+import { PublicEnvScript } from 'next-runtime-env';
 
 const PREFERS_DARK_KEY = 'prefers-dark';
 
@@ -64,6 +65,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <>
       <title>Buildbarn Portal</title>
       <html lang="en" className={styles.html}>
+        <head>
+          <PublicEnvScript />
+        </head>
         <body className={styles.body}>
           <div style={{ display: "flex" }}>
             <ApolloWrapper>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,8 +5,9 @@ import { Divider, Space, Typography } from 'antd';
 import styles from './page.module.css';
 import Content from '@/components/Content';
 import Uploader from '@/components/Uploader';
+import { env } from 'next-runtime-env';
 
-const bazelrcLines = `build --bes_backend=${process.env.NEXT_PUBLIC_BES_GRPC_BACKEND_URL}\nbuild --bes_results_url=${process.env.NEXT_PUBLIC_BES_BACKEND_URL}/bazel-invocations/`;
+const bazelrcLines = `build --bes_backend=${env('NEXT_PUBLIC_BES_GRPC_BACKEND_URL')}\nbuild --bes_results_url=${env('NEXT_PUBLIC_BES_BACKEND_URL')}/bazel-invocations/`;
 
 export default function Home() {
   return (
@@ -15,7 +16,7 @@ export default function Home() {
         <div className={styles.container}>
           <Space direction="vertical" size="large">
             <Typography.Title level={1} className={styles.item}>
-              Welcome to the {process.env.NEXT_PUBLIC_COMPANY_NAME} Buildbarn Portal
+              Welcome to the {env('NEXT_PUBLIC_COMPANY_NAME')} Buildbarn Portal
             </Typography.Title>
             <Typography.Title level={5} className={styles.item}>
               Providing insights into Bazel build outputs

--- a/frontend/src/components/ApolloWrapper/index.tsx
+++ b/frontend/src/components/ApolloWrapper/index.tsx
@@ -8,10 +8,12 @@ import {
   SSRMultipartLink,
 } from '@apollo/experimental-nextjs-app-support/ssr';
 import possibleTypes from './possibleTypes.json';
+import { env } from 'next-runtime-env';
+
 
 export const makeClient = () => {
   const httpLink = new HttpLink({
-    uri: `${process.env.NEXT_PUBLIC_BES_BACKEND_URL}/graphql`,
+    uri: `${env('NEXT_PUBLIC_BES_BACKEND_URL')}/graphql`,
     fetchOptions: { cache: "no-store" },
   });
 

--- a/frontend/src/components/AppBar/AppBarTitle.tsx
+++ b/frontend/src/components/AppBar/AppBarTitle.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 import { Typography } from 'antd';
 import Link from 'next/link';
 import styles from '@/components/AppBar/index.module.css';
+import { env } from 'next-runtime-env';
+
 
 const AppBarTitle = () => {
   return (
     <div className={styles.title}>
       <Link href="/">
-        <Typography.Title level={3}>{process.env.NEXT_PUBLIC_COMPANY_NAME} Buildbarn Portal</Typography.Title>
+        <Typography.Title level={3}>{env('NEXT_PUBLIC_COMPANY_NAME')} Buildbarn Portal</Typography.Title>
       </Link>
     </div>
   );

--- a/frontend/src/components/BazelInvocation/index.tsx
+++ b/frontend/src/components/BazelInvocation/index.tsx
@@ -50,6 +50,8 @@ import MemoryMetricsDisplay from "../MemoryMetrics";
 import TimingMetricsDisplay from "../TimingMetrics";
 import NetworkMetricsDisplay from "../NetworkMetrics";
 import TestMetricsDisplay from "../TestsMetrics";
+import { env } from 'next-runtime-env';
+
 
 const BazelInvocation: React.FC<{
   invocationOverview: BazelInvocationInfoFragment;
@@ -256,8 +258,8 @@ const BazelInvocation: React.FC<{
     <PortalDuration key="duration" from={invocationOverview.startedAt} to={invocationOverview.endedAt} includeIcon includePopover />,
   ];
 
-  if (process.env.NEXT_PUBLIC_BROWSER_URL && profile) {
-    var url = new URL(`blobs/sha256/file/${profile.digest}-${profile.sizeInBytes}/${profile.name}`, process.env.NEXT_PUBLIC_BROWSER_URL)
+  if (env('NEXT_PUBLIC_BROWSER_URL') && profile) {
+    var url = new URL(`blobs/sha256/file/${profile.digest}-${profile.sizeInBytes}/${profile.name}`, env('NEXT_PUBLIC_BROWSER_URL'))
     extraBits.push(
       <DownloadButton url={url.toString()} fileName="profile" buttonLabel="Profile" enabled={true} />
     );

--- a/frontend/src/components/FooterBar/index.tsx
+++ b/frontend/src/components/FooterBar/index.tsx
@@ -5,6 +5,7 @@ import { Layout, Popover, Space } from 'antd';
 import { SlackOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import styles from '@/components/FooterBar/index.module.css';
+import { env } from 'next-runtime-env';
 
 interface Props {
   className?: string;
@@ -17,11 +18,11 @@ const FooterBar: React.FC<Props> = ({ className, linkItemClassName }) => {
   return (
     <Layout.Footer className={`${className} ${styles.footerBar}`}>
       <Space size="large">
-        <Popover content={"#" + process.env.NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME} className={linkClassName}>
-          <Link href={process.env.NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_URL ?? ""} target="_blank" hidden={process.env.NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME == undefined}>
+        <Popover content={"#" + env('NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME')} className={linkClassName}>
+          <Link href={env('NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_URL') ?? ""} target="_blank" hidden={env('NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME') == undefined}>
             <Space>
               <SlackOutlined />
-              {process.env.NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME}
+              {env('NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME')}
             </Space>
           </Link>
         </Popover>


### PR DESCRIPTION
currently there is no way aside from rebuilding the image to inject environment variables that nextjs will actually respect at runtime, they have to be supplied at build time.  

this PR adds a package to help handle this
https://github.com/expatfile/next-runtime-env/tree/development
