### PR TITLE
Register no-op archiver for bytestream URIs

### DIFF
--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -115,8 +115,12 @@ func configureBlobArchiving(blobArchiver processing.BlobMultiArchiver, archiveFo
 	if err != nil {
 		fatal("failed to create blob archive folder", "folder", archiveFolder, "err", err)
 	}
+
 	localBlobArchiver := processing.NewLocalFileArchiver(archiveFolder)
 	blobArchiver.RegisterArchiver("file", localBlobArchiver)
+
+	noopArchiver := processing.NewNoopArchiver()
+	blobArchiver.RegisterArchiver("bytestream", noopArchiver)
 }
 
 func runWatcher(watcher *fsnotify.Watcher, client *ent.Client, bepFolder string, blobArchiver processing.BlobMultiArchiver) {

--- a/pkg/processing/archive.go
+++ b/pkg/processing/archive.go
@@ -125,3 +125,21 @@ func (lfa LocalFileArchiver) archiveBlob(blobURI detectors.BlobURI) (*ent.Blob, 
 		ArchiveURL: destPath,
 	}, nil
 }
+
+// NoopArchiver is an archiver which does not archive blobs. This is useful in situations where
+// it is desirable to register an archiver for some URI scheme, without archiving those blobs.
+type NoopArchiver struct{}
+
+// NewNoopArchiver creates a new NoopArchiver
+func NewNoopArchiver() NoopArchiver {
+	return NoopArchiver{}
+}
+
+// ArchiveBlob Archive Blob function.
+func (na NoopArchiver) ArchiveBlob(_ context.Context, blobURI detectors.BlobURI) ent.Blob {
+	return ent.Blob{
+		URI:        string(blobURI),
+		SizeBytes:  0,
+		ArchiveURL: "",
+	}
+}


### PR DESCRIPTION
We currently throw an error when attempting to archive bytestream URIs. It seems better to silently continue, and handle the fact that we will be unable to show these blobs later.

Longer term, the intention is to suppose bytestream URIs, but that work has not yet been done.

Work towards fixing https://github.com/buildbarn/bb-portal/issues/35