### PR TITLE
Force complete retransmit on retry

### DIFF
--- a/internal/api/grpc/bes/BUILD.bazel
+++ b/internal/api/grpc/bes/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
         "//pkg/summary",
         "//third_party/bazel/gen/bes",
         "@org_golang_google_genproto//googleapis/devtools/build/v1:build",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//types/known/emptypb",
     ],

--- a/internal/api/grpc/bes/server.go
+++ b/internal/api/grpc/bes/server.go
@@ -59,7 +59,7 @@ func (s BuildEventServer) PublishBuildToolEventStream(stream build.PublishBuildE
 	var streamID *build.StreamId
 	reqCh := make(chan *build.PublishBuildToolEventStreamRequest)
 	errCh := make(chan error)
-	var eventCh *BuildEventChannel
+	var eventCh BuildEventChannel
 
 	go func() {
 		for {
@@ -110,10 +110,10 @@ func (s BuildEventServer) PublishBuildToolEventStream(stream build.PublishBuildE
 			return err
 
 		case req := <-reqCh:
-			// First request
+			// First event
 			if streamID == nil {
 				streamID = req.OrderedBuildEvent.GetStreamId()
-				eventCh = s.handler.CreateEventChannel(stream.Context(), streamID)
+				eventCh = s.handler.CreateEventChannel(stream.Context(), req.OrderedBuildEvent)
 			}
 
 			seqNrs = append(seqNrs, req.OrderedBuildEvent.GetSequenceNumber())


### PR DESCRIPTION
This introduces two changes:

**[Ack all events after receiving the entire set, to force complete retransmit on failure](https://github.com/buildbarn/bb-portal/commit/dc7754c21394e2bbfc1b0053b26b379212748acb)** 

Deferring the acknowledgement of incoming events until all events in a stream are received
and processed greatly simplifies handling of retries. While it would, in some ways, be
more efficient if we were able to resume transmission in a way that only required missed
events to be retransmitted, this would complicate matters in others. For one, we would
need to persist data as we received the events. We would also need to handle the scenario
where the retry is sent to a different instance of the server, in a setting where the
server is scaled out horizontally.

While there are certainly solutions we might investigate that allow us to support resuming on retry,
it is for now far simpler to require a complete retransmission of events.

**[Avoid repeated processing if the client retries](https://github.com/buildbarn/bb-portal/commit/0533d545fe510847329ca6bbfd1ba2bea7871324)**

We now ack all events after the entire stream of events is received and
processed. This means that if the client retries, it can be expected
to retry from the start of the stream such that any new request
should always start with sequence number 1.

If, however, our response to the client is dropped, it is possible
for the client to begin its retry from some other position. In this
situation we would already have persisted the event stream. If this occurs
we should simply skip any processing and ack the events.