### PR TITLE
fix panic on UUID failing to parse for canceled builds

### DIFF
--- a/pkg/processing/save.go
+++ b/pkg/processing/save.go
@@ -133,8 +133,14 @@ func (act SaveActor) saveBazelInvocation(
 	tests []*ent.TestCollection,
 	targets []*ent.TargetPair,
 ) (*ent.BazelInvocation, error) {
+
+	uniqueId, err := uuid.Parse(summary.InvocationID)
+	if err != nil {
+		return nil, err
+	}
+
 	create := act.db.BazelInvocation.Create().
-		SetInvocationID(uuid.MustParse(summary.InvocationID)).
+		SetInvocationID(uniqueId).
 		SetProfileName(summary.ProfileName).
 		SetStartedAt(summary.StartedAt).
 		SetNillableEndedAt(summary.EndedAt).

--- a/pkg/processing/save.go
+++ b/pkg/processing/save.go
@@ -133,12 +133,10 @@ func (act SaveActor) saveBazelInvocation(
 	tests []*ent.TestCollection,
 	targets []*ent.TargetPair,
 ) (*ent.BazelInvocation, error) {
-
 	uniqueId, err := uuid.Parse(summary.InvocationID)
 	if err != nil {
 		return nil, err
 	}
-
 	create := act.db.BazelInvocation.Create().
 		SetInvocationID(uniqueId).
 		SetProfileName(summary.ProfileName).

--- a/pkg/processing/save.go
+++ b/pkg/processing/save.go
@@ -133,12 +133,12 @@ func (act SaveActor) saveBazelInvocation(
 	tests []*ent.TestCollection,
 	targets []*ent.TargetPair,
 ) (*ent.BazelInvocation, error) {
-	uniqueId, err := uuid.Parse(summary.InvocationID)
+	uniqueID, err := uuid.Parse(summary.InvocationID)
 	if err != nil {
 		return nil, err
 	}
 	create := act.db.BazelInvocation.Create().
-		SetInvocationID(uniqueId).
+		SetInvocationID(uniqueID).
 		SetProfileName(summary.ProfileName).
 		SetStartedAt(summary.StartedAt).
 		SetNillableEndedAt(summary.EndedAt).


### PR DESCRIPTION
still seeing an issue when builds are cancelled where the application panics if it can't parse a UUID for a given invocation. Throws the following stack trace

`2024/10/22 12:44:03 INFO Stream started event="context.Background.WithValue(transport.connectionKey, *net.TCPConn).WithValue(peer.peerKey, Peer{Addr: '10.10.10.228:35658', LocalAddr: '10.10.5.119:8082', AuthInfo: <nil>}).WithCancel.WithValue(metadata.mdIncomingKey, metadata.MD).WithValue(grpc.serverKey, *grpc.Server).WithValue(grpc.streamKey, *transport.Stream).WithValue(grpc.rpcInfoContextKey, *grpc.rpcInfo).WithValue(trace.traceContextKeyType, trace.nonRecordingSpan).WithValue(trace.traceContextKeyType, global.nonRecordingSpan).WithValue(auth.authenticationMetadataKey, *auth.AuthenticationMetadata)"
2024/10/22 12:44:07 INFO Stream finished event="context.Background.WithValue(transport.connectionKey, *net.TCPConn).WithValue(peer.peerKey, Peer{Addr: '10.10.10.228:35658', LocalAddr: '10.10.5.119:8082', AuthInfo: <nil>}).WithCancel.WithValue(metadata.mdIncomingKey, metadata.MD).WithValue(grpc.serverKey, *grpc.Server).WithValue(grpc.streamKey, *transport.Stream).WithValue(grpc.rpcInfoContextKey, *grpc.rpcInfo).WithValue(trace.traceContextKeyType, trace.nonRecordingSpan).WithValue(trace.traceContextKeyType, global.nonRecordingSpan).WithValue(auth.authenticationMetadataKey, *auth.AuthenticationMetadata)"
2024/10/22 12:44:07 INFO Saving invocation id="build_id:\"b947b352-7c46-4144-bc89-5fa5ba581647\" invocation_id:\"6c6acecc-f45a-4abd-a7d3-e34176cbfd5d\" component:TOOL"
panic: uuid: Parse(): invalid UUID length: 0

goroutine 102053 [running]:
github.com/google/uuid.MustParse({0x0, 0x0})
        external/gazelle~~go_deps~com_github_google_uuid/uuid.go:169 +0x99
github.com/buildbarn/bb-portal/pkg/processing.SaveActor.saveBazelInvocation({0xc00049eea0?, {0xc0008aa060?}}, {0x27a96a8, 0xc002a548d0}, 0xc000a40008, 0xc00083c240, 0x0, 0xc0001aeea0, {0x3cce2c0, 0x0, ...}, ...)
        pkg/processing/save.go:137 +0x86
github.com/buildbarn/bb-portal/pkg/processing.SaveActor.SaveSummary({0xc00049eea0, {0xc0008aa060}}, {0x27a96a8, 0xc002a548d0}, 0xc000a40008)
        pkg/processing/save.go:58 +0x90f
github.com/buildbarn/bb-portal/internal/api/grpc/bes.(*buildEventChannel).Finalize(0xc00222b380)
        internal/api/grpc/bes/channel.go:73 +0x2fe
github.com/buildbarn/bb-portal/internal/api/grpc/bes.BuildEventServer.PublishBuildToolEventStream({0x10?}, {0x27b1f78, 0xc001dd9ee0})
        internal/api/grpc/bes/server.go:96 +0x8a5
google.golang.org/genproto/googleapis/devtools/build/v1._PublishBuildEvent_PublishBuildToolEventStream_Handler({0x20c9500?, 0xc000094698}, {0x27af078, 0xc000703ba0})
        external/gazelle~~go_deps~org_golang_google_genproto/googleapis/devtools/build/v1/publish_build_event.pb.go:817 +0xd8
github.com/buildbarn/bb-storage/pkg/grpc.NewServersFromConfigurationAndServe.NewAuthenticatingStreamInterceptor.func5({0x20c9500, 0xc000094698}, {0x27afc48, 0xc001257540}, 0xc001257580?, 0x25007f0)
        external/com_github_buildbarn_bb_storage~/pkg/grpc/authenticating_interceptor.go:43 +0x13c
google.golang.org/grpc.getChainStreamHandler.func1({0x20c9500, 0xc000094698}, {0x27afc48, 0xc001257540})
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1540 +0xb2
github.com/buildbarn/bb-storage/pkg/grpc.RequestMetadataTracingStreamInterceptor({0x20c9500, 0xc000094698}, {0x27afc48, 0xc001257540}, 0xc001845380?, 0xc001257580)
        external/com_github_buildbarn_bb_storage~/pkg/grpc/request_metadata_tracing_interceptor.go:29 +0x56
google.golang.org/grpc.getChainStreamHandler.func1({0x20c9500, 0xc000094698}, {0x27afc48, 0xc001257540})
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1540 +0xb2
go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.StreamServerInterceptor.func1({0x20c9500, 0xc000094698}, {0x27afb70, 0xc001845398}, 0xc001845380, 0xc0012574c0)
        external/gazelle~~go_deps~io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc/interceptor.go:436 +0x5b8
google.golang.org/grpc.getChainStreamHandler.func1({0x20c9500, 0xc000094698}, {0x27afb70, 0xc001845398})
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1540 +0xb2
github.com/grpc-ecosystem/go-grpc-prometheus.init.(*ServerMetrics).StreamServerInterceptor.func4({0x20c9500, 0xc000094698}, {0x27af030, 0xc000c103c0}, 0xc001845380, 0xc001257480)
        external/gazelle~~go_deps~com_github_grpc_ecosystem_go_grpc_prometheus/server_metrics.go:121 +0xd2
google.golang.org/grpc.NewServer.chainStreamServerInterceptors.chainStreamInterceptors.func2({0x20c9500, 0xc000094698}, {0x27af030, 0xc000c103c0}, 0xc001845380, 0xc001dd9e00?)
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1531 +0x85
google.golang.org/grpc.(*Server).processStreamingRPC(0xc00045c000, {0x27a96a8, 0xc002a546f0}, {0x27b4020, 0xc000724680}, 0xc000694480, 0xc0008aac00, 0x39fd580, 0x0)
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1695 +0x11e7
google.golang.org/grpc.(*Server).handleStream(0xc00045c000, {0x27b4020, 0xc000724680}, 0xc000694480)
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1809 +0xe3a
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1029 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 100255
        external/gazelle~~go_deps~org_golang_google_grpc/server.go:1040 +0x125`

If we hit this, better to just bail out than crash the application. 