### PR TITLE
Frontend improvements

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -4,3 +4,4 @@ NEXT_PUBLIC_BROWSER_URL=https://browser.example.com
 NEXT_PUBLIC_COMPANY_NAME="Example Co"
 NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME=ExampleCoBuild
 NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_URL=https://exampleco.enterprise.slack.com/archives/CXXXXXXX
+NEXT_PUBLIC_GITHUB_URL=https://github.com/

--- a/frontend/.env
+++ b/frontend/.env
@@ -4,4 +4,4 @@ NEXT_PUBLIC_BROWSER_URL=https://browser.example.com
 NEXT_PUBLIC_COMPANY_NAME="Example Co"
 NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_NAME=ExampleCoBuild
 NEXT_PUBLIC_COMPANY_SLACK_CHANNEL_URL=https://exampleco.enterprise.slack.com/archives/CXXXXXXX
-NEXT_PUBLIC_GITHUB_URL=https://github.com/
+NEXT_PUBLIC_GITHUB_URL=https://github.com

--- a/frontend/src/app/tests/[slug]/page.tsx
+++ b/frontend/src/app/tests/[slug]/page.tsx
@@ -14,7 +14,7 @@ interface PageParams {
 }
 
 const Page: React.FC<PageParams> = ({ params }) => {
-    const label = decodeURIComponent(params.slug)
+    const label = decodeURIComponent(atob(decodeURIComponent(params.slug)))
     return (
         <Content
             content={

--- a/frontend/src/components/Breadcrumbs/index.tsx
+++ b/frontend/src/components/Breadcrumbs/index.tsx
@@ -45,6 +45,21 @@ const Breadcrumbs: React.FC<Props> = ({ segmentTitles }) => {
       // For example, convert "/foo/bar/baz" to ["foo", "bar", "baz"]
       const segments = pathname.split(separator).filter(segment => segment.length > 0);
 
+      //special handling for the base64 encoded route params to get around nextjs being overly helpful and decoding urls automagically
+      if (segments.includes("tests")) {
+        var idx = segments.indexOf("tests")
+        if (idx + 1 < segments.length) {
+          segments[idx + 1] = atob(segments[idx + 1])
+        }
+      }
+      //for future targets route
+      if (segments.includes("targets")) {
+        var idx = segments.indexOf("targets")
+        if (idx + 1 < segments.length) {
+          segments[idx + 1] = atob(segments[idx + 1])
+        }
+      }
+
       // Iterate over the list of segments to build a breadcrumb object for each
       const breadcrumbs = segments.map((segment, index) => {
         // Compose the path by joining all preceding segments

--- a/frontend/src/components/CommandLine/index.tsx
+++ b/frontend/src/components/CommandLine/index.tsx
@@ -16,31 +16,14 @@ const CommandLineDisplay: React.FC<{ commandLineData: BazelCommand | undefined |
     commandLineData: commandLineData
 }) => {
 
-    const createUnorderedList = (items: string[]): JSX.Element => {
-        return (
-            <ul>
-                {items.map((item, index) => (
-                    <li key={index}>{item}</li>
-                ))}
-            </ul>
-        );
-    };
-
     var commandLineOptions: string[] = []
     commandLineData?.cmdLine?.forEach(x => commandLineOptions.push(x ?? ""))
+    var cmdLine = [commandLineData?.executable, commandLineData?.command, commandLineData?.residual, commandLineData?.explicitCmdLine].join(" ")
 
     return (
 
         <Space direction="vertical" size="middle" style={{ display: 'flex' }} >
-            <PortalCard type="inner" icon={<CodeOutlined />} titleBits={["Command Line"]}>
-                <Row>
-                    <Space size="large">
-                        <strong>Explicit Command Line:</strong>
-                        <div>
-                            {commandLineData?.executable} {commandLineData?.command} {commandLineData?.residual} {commandLineData?.explicitCmdLine}
-                        </div>
-                    </Space>
-                </Row>
+            <PortalCard type="inner" icon={<CodeOutlined />} titleBits={["Explicit Command Line:", cmdLine]}>
                 <Row>
                     <Space size="large">
                         <div>
@@ -50,13 +33,24 @@ const CommandLineDisplay: React.FC<{ commandLineData: BazelCommand | undefined |
                                 dataSource={commandLineData?.cmdLine?.filter(x => x !== undefined).toSorted() as string[]}
                                 renderItem={(item) => <List.Item>{item}</List.Item>}
                             />
-
+                        </div>
+                    </Space>
+                </Row>
+                <Row>
+                    <Space size="large">
+                        <div>
                             <List
                                 bordered
                                 header={<div><strong>Explicit Startup Options:</strong></div>}
                                 dataSource={commandLineData?.explicitStartupOptions?.filter(x => x !== undefined) as string[]}
                                 renderItem={(item) => <List.Item>{item}</List.Item>}
                             />
+                        </div>
+                    </Space>
+                </Row>
+                <Row>
+                    <Space size="large">
+                        <div>
                             <List
                                 bordered
                                 header={<div><strong>Effective Startup Options:</strong></div>}

--- a/frontend/src/components/SourceControlDisplay/index.tsx
+++ b/frontend/src/components/SourceControlDisplay/index.tsx
@@ -1,28 +1,26 @@
 import React from "react";
-import { Space, Table, Row, Col, Statistic, List, Descriptions } from 'antd';
-import { BranchesOutlined, CodeOutlined, DeploymentUnitOutlined, SearchOutlined } from '@ant-design/icons';
-import type { StatisticProps, TableColumnsType } from "antd/lib";
-import CountUp from 'react-countup';
-import { BazelCommand, SourceControl, TargetMetrics, TargetPair } from "@/graphql/__generated__/graphql";
+import { Space, Row, Descriptions } from 'antd';
+import { BranchesOutlined } from '@ant-design/icons';
+import { SourceControl } from "@/graphql/__generated__/graphql";
 import PortalCard from "../PortalCard";
-import { SearchFilterIcon, SearchWidget } from '@/components/SearchWidgets';
-import NullBooleanTag from "../NullableBooleanTag";
-import styles from "../../theme/theme.module.css"
-import { millisecondsToTime } from "../Utilities/time";
 import Link from "next/link";
-
+import { env } from 'next-runtime-env';
 
 
 const SourceControlDisplay: React.FC<{ sourceControlData: SourceControl | undefined | null }> = ({
     sourceControlData: sourceControlData
 }) => {
     //build urls
-    const runURL = sourceControlData?.repoURL + "/actions/runs/" + "10976627244"
-    const actorURL = "https://github.com/" + sourceControlData?.actor
-    const branchURL = sourceControlData?.repoURL + "/tree/" + sourceControlData?.branch
-    const commitURL = sourceControlData?.repoURL + "/commit/" + sourceControlData?.commitSha
+    var ghUrl = env('NEXT_PUBLIC_GITHUB_URL') ?? "https://github.com/"
+    if (!ghUrl.endsWith("/")) {
+        ghUrl += "/"
+    }
+    const runURL = ghUrl + sourceControlData?.repoURL + "/actions/runs/" + "10976627244"
+    const actorURL = ghUrl + sourceControlData?.actor
+    const branchURL = ghUrl + sourceControlData?.repoURL + "/tree/" + sourceControlData?.branch
+    const commitURL = ghUrl + sourceControlData?.repoURL + "/commit/" + sourceControlData?.commitSha
     const prParts = sourceControlData?.refs?.split("/") ?? ""
-    const prURL = sourceControlData?.repoURL + "/" + prParts[1] + "/" + prParts[2]
+    const prURL = ghUrl + sourceControlData?.repoURL + "/" + prParts[1] + "/" + prParts[2]
 
     return (
         <Space direction="vertical" size="middle" style={{ display: 'flex' }} >

--- a/frontend/src/components/TestGrid/index.tsx
+++ b/frontend/src/components/TestGrid/index.tsx
@@ -46,7 +46,9 @@ const columns: TableColumnsType<TestGridRowDataType> = [
     title: "Label",
     dataIndex: "label",
     filterSearch: true,
-    render: (_, record) => <Link href={"tests/" + encodeURIComponent(record.label)}>{record.label}</Link>,
+    render: (_, record) =>
+
+      <Link href={"tests/" + btoa(encodeURIComponent(record.label))}>{record.label}</Link>,
     filterDropdown: filterProps => (
       <SearchWidget placeholder="Target Pattern..." {...filterProps} />
     ),
@@ -123,14 +125,11 @@ const TestGrid: React.FC<Props> = () => {
       var vars: GetTestsWithOffsetQueryVariables = {}
       if (filters['label']?.length) {
         var label = filters['label']?.[0]?.toString() ?? ""
-        console.log(label)
         vars.label = label
       } else {
         vars.label = ""
       }
-      console.log("pagination.curreent", pagination.current)
       vars.offset = ((pagination.current ?? 1) - 1) * PAGE_SIZE;
-      console.log(vars.offset)
       setVariables(vars)
     },
     [variables],

--- a/frontend/src/components/TestGridBtn/index.tsx
+++ b/frontend/src/components/TestGridBtn/index.tsx
@@ -39,35 +39,35 @@ const TestGridBtn: React.FC<Props> = ({ status, invocationId }) => {
 
         ),
         PASSED: (
-            <Button href={"/bazel-invocations/" + invocationId} icon={<CheckCircleFilled />} color="success" className={themeStyles.colorSuccess} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<CheckCircleFilled />} className={themeStyles.colorSuccess} />
 
         ),
         FLAKY: (
-            <Button icon={<InfoCircleFilled />} color="warning" className={themeStyles.colorAborted} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<InfoCircleFilled />} className={themeStyles.colorAborted} />
 
         ),
         FAILED: (
-            <Button icon={<CloseCircleFilled />} color="danger" className={themeStyles.colorFailure} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<CloseCircleFilled />} color="danger" className={themeStyles.colorFailure} />
 
         ),
         TIMEOUT: (
-            <Button icon={<MinusCircleFilled />} color="danger" className={themeStyles.colorFailure} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<MinusCircleFilled />} color="danger" className={themeStyles.colorFailure} />
 
         ),
         INCOMPLETE: (
-            <Button icon={<StopOutlined />} color="secondary" className={themeStyles.colorAborted} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<StopOutlined />} className={themeStyles.colorAborted} />
 
         ),
         REMOTE_FAILURE: (
-            <Button icon={<CloseCircleFilled />} color="danger" className={themeStyles.colorFailure} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<CloseCircleFilled />} color="danger" className={themeStyles.colorFailure} />
 
         ),
         FAILED_TO_BUILD: (
-            <Button icon={<QuestionCircleFilled />} color="danger" className={themeStyles.colorFailure} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<QuestionCircleFilled />} color="danger" className={themeStyles.colorFailure} />
 
         ),
         TOOL_HALTED_BEFORE_TESTING: (
-            <Button icon={<QuestionCircleFilled />} color="secondary" className={themeStyles.colorDisabled} />
+            <Button href={"/bazel-invocations/" + invocationId} icon={<QuestionCircleFilled />} className={themeStyles.colorDisabled} />
         ),
     };
 

--- a/frontend/src/components/TestsMetrics/index.tsx
+++ b/frontend/src/components/TestsMetrics/index.tsx
@@ -75,7 +75,7 @@ const test_columns: TableColumnsType<TestDataType> = [
     {
         title: "Label",
         dataIndex: "name",
-        render: (_, record) => <Link href={"/tests/" + encodeURIComponent(record.name)}>{record.name}</Link>,
+        render: (_, record) => <Link href={"/tests/" + btoa(encodeURIComponent(record.name))}>{record.name}</Link>,
         filterSearch: true,
         filterDropdown: filterProps => (
             <SearchWidget placeholder="Target Pattern..." {...filterProps} />


### PR DESCRIPTION
This PR does the following:
- provide support for on-prem gh servers and fix PR/repo/etc links
- clean up tab hide/show functionality for bazel invocation view
- adjust layout of command line view
- base64 encode test slugs to get around newest version of nextjs providing no option to skip decoding route URIs.  route URIs for test slugs can contain slashes.  previously these slashes were encoded and decoded manually at appropriate places to allow us to workaround routes containing slashes, but recent updates broke this functionality.  the URL itself is still displayed as a base64 encoded string.  ideally i'd prefer slightly friendlier routes, but for now, this should work