### PR TITLE
Push Database Finish Processing Tasks to context background process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ download:
 
 .PHONY: lint
 lint:
-	golangci-lint --timeout 10m run ./...
+	bazel mod tidy
+	bazel run //:gazelle
+	bazel run @com_github_bazelbuild_buildtools//:buildifier
+	bazel run @cc_mvdan_gofumpt//:gofumpt -- -w -extra $(CURDIR)
+	bazel run @org_golang_x_lint//golint -- -set_exit_status $(CURDIR)/...
+	bazel test //...
 
 .PHONY: lint-fix
 lint-fix:

--- a/ent/gen/ent/migrate/schema.go
+++ b/ent/gen/ent/migrate/schema.go
@@ -348,7 +348,7 @@ var (
 	// EventFilesColumns holds the columns for the "event_files" table.
 	EventFilesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
-		{Name: "url", Type: field.TypeString, Unique: true},
+		{Name: "url", Type: field.TypeString},
 		{Name: "mod_time", Type: field.TypeTime},
 		{Name: "protocol", Type: field.TypeString},
 		{Name: "mime_type", Type: field.TypeString},

--- a/ent/schema/eventfile.go
+++ b/ent/schema/eventfile.go
@@ -15,7 +15,7 @@ type EventFile struct {
 // Fields of the EventFile.
 func (EventFile) Fields() []ent.Field {
 	return []ent.Field{
-		field.String("url").Unique().Immutable(),
+		field.String("url").Immutable(),
 		field.Time("mod_time"),
 		field.String("protocol"), // *.bep, *.log, etc
 		field.String("mime_type"),

--- a/frontend/src/components/BazelInvocationsTable/index.tsx
+++ b/frontend/src/components/BazelInvocationsTable/index.tsx
@@ -30,7 +30,7 @@ const BazelInvocationsTable: React.FC<Props> = ({ height }) => {
   const { loading, data, previousData, error } = useQuery(FIND_BAZEL_INVOCATIONS_QUERY, {
     variables,
     pollInterval: 120000,
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: "network-only",
   });
 
   const onChange: TableProps<BazelInvocationNodeFragment>['onChange'] = useCallback(

--- a/internal/api/grpc/bes/channel.go
+++ b/internal/api/grpc/bes/channel.go
@@ -88,7 +88,7 @@ func (c *buildEventChannel) Finalize() error {
 			"component", c.streamID.GetComponent())
 	}
 
-	invocation, err := c.workflow.SaveSummary(ctx, summaryReport) // will c.workflow still be there?
+	invocation, err := c.workflow.SaveSummary(ctx, summaryReport)
 	if err != nil {
 		slog.ErrorContext(ctx, "SaveSummary failed", "err", err)
 		cancel()

--- a/internal/api/grpc/bes/channel.go
+++ b/internal/api/grpc/bes/channel.go
@@ -39,7 +39,6 @@ func (c *buildEventChannel) HandleBuildEvent(event *build.BuildEvent) error {
 	if event.GetBazelEvent() == nil {
 		return nil
 	}
-
 	var bazelEvent bes.BuildEvent
 	err := event.GetBazelEvent().UnmarshalTo(&bazelEvent)
 	if err != nil {
@@ -56,6 +55,10 @@ func (c *buildEventChannel) HandleBuildEvent(event *build.BuildEvent) error {
 
 // Finalize implements BuildEventChannel.Finalize.
 func (c *buildEventChannel) Finalize() error {
+	// defer the ctx so its not reaped when the client closes the connection
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour*24)
+	defer cancel()
+
 	summaryReport, err := c.summarizer.FinishProcessing()
 	if err != nil {
 		slog.ErrorContext(c.ctx, "FinishProcessing failed", "err", err)
@@ -64,19 +67,38 @@ func (c *buildEventChannel) Finalize() error {
 
 	// Hack for eventFile being required
 	summaryReport.EventFileURL = fmt.Sprintf(
-		"grpc://localhost:8082/google.devtools.build.v1/PublishLifecycleEvent?streamID=%s",
-		c.streamID.String(),
+		"grpc://localhost:8082/google.devtools.build.v1/PublishLifecycleEvent?invocationId=%s&buildID=%s&component=%s",
+		c.streamID.GetInvocationId(), c.streamID.GetBuildId(), c.streamID.GetComponent(),
 	)
 
-	slog.InfoContext(c.ctx, "Saving invocation", "id", c.streamID.String())
+	slog.InfoContext(c.ctx, "Saving invocation",
+		"InvocationId", c.streamID.GetInvocationId(),
+		"BuildId", c.streamID.GetBuildId(),
+		"Component", c.streamID.GetComponent())
+
 	startTime := time.Now()
-	invocation, err := c.workflow.SaveSummary(c.ctx, summaryReport)
+
+	// try to get the invocation id
+	if summaryReport.InvocationID == "" {
+		summaryReport.InvocationID = c.streamID.GetInvocationId()
+		slog.WarnContext(c.ctx, "summaryReport was missing invocation ID",
+			"invocationId", c.streamID.GetInvocationId(),
+			"buildId", c.streamID.GetBuildId(),
+			"component", c.streamID.GetComponent())
+	}
+
+	invocation, err := c.workflow.SaveSummary(ctx, summaryReport) // will c.workflow still be there?
 	if err != nil {
-		slog.ErrorContext(c.ctx, "SaveSummary failed", "err", err)
+		slog.ErrorContext(ctx, "SaveSummary failed", "err", err)
+		cancel()
 		return err
 	}
+
+	cancel()
+
 	endTime := time.Now()
 	elapsedTime := endTime.Sub(startTime)
+
 	slog.InfoContext(c.ctx, fmt.Sprintf("Saved invocation in %v", elapsedTime.String()), "id", invocation.InvocationID)
 	return nil
 }

--- a/internal/api/grpc/bes/channel.go
+++ b/internal/api/grpc/bes/channel.go
@@ -62,6 +62,7 @@ func (c *buildEventChannel) Finalize() error {
 	summaryReport, err := c.summarizer.FinishProcessing()
 	if err != nil {
 		slog.ErrorContext(c.ctx, "FinishProcessing failed", "err", err)
+		cancel()
 		return err
 	}
 

--- a/internal/api/grpc/bes/server.go
+++ b/internal/api/grpc/bes/server.go
@@ -47,12 +47,32 @@ func (s BuildEventServer) PublishBuildToolEventStream(stream build.PublishBuildE
 	// We'll want to ack these once all events are received, as we don't support resumption.
 	seqNrs := make([]int64, 0)
 
-	ack := func(streamID *build.StreamId, sequenceNumber int64) {
+	ack := func(streamID *build.StreamId, sequenceNumber int64, isClosing bool) {
 		if err := stream.Send(&build.PublishBuildToolEventStreamResponse{
 			StreamId:       streamID,
 			SequenceNumber: sequenceNumber,
 		}); err != nil {
-			slog.ErrorContext(stream.Context(), "Send failed", "err", err, "streamid", streamID, "sequenceNumber", sequenceNumber)
+
+			// with the option --bes_uplod_mode=fully_async or nowait_for_upload_complete
+			// its not an error when the send fails. the bes gracefully terminated the close
+			// i.e. sent an EOF. for long running builds that take a while to save to the db (> 1s)
+			// the context is processed in the background, so by the time we are acknowledging these
+			// requests, the client connection may have already timed out and these errors can be
+			// safely ignored
+			if isClosing && (err.Error() != "rpc error: code = Unavailable desc = transport is closing") {
+				return
+			}
+
+			slog.ErrorContext(
+				stream.Context(),
+				"Send failed",
+				"err",
+				err,
+				"streamid",
+				streamID,
+				"sequenceNumber",
+				sequenceNumber,
+			)
 		}
 	}
 
@@ -77,7 +97,9 @@ func (s BuildEventServer) PublishBuildToolEventStream(stream build.PublishBuildE
 		case err := <-errCh:
 			if err == io.EOF {
 				slog.InfoContext(stream.Context(), "Stream finished", "event", stream.Context())
+
 				if eventCh == nil {
+					slog.WarnContext(stream.Context(), "No event channel found for stream event", "event", stream.Context())
 					return nil
 				}
 
@@ -100,7 +122,7 @@ func (s BuildEventServer) PublishBuildToolEventStream(stream build.PublishBuildE
 
 				// Ack all events
 				for _, seqNr := range seqNrs {
-					ack(streamID, seqNr)
+					ack(streamID, seqNr, true)
 				}
 
 				return nil

--- a/internal/api/grpc/bes/server.go
+++ b/internal/api/grpc/bes/server.go
@@ -52,7 +52,7 @@ func (s BuildEventServer) PublishBuildToolEventStream(stream build.PublishBuildE
 			StreamId:       streamID,
 			SequenceNumber: sequenceNumber,
 		}); err != nil {
-			slog.ErrorContext(stream.Context(), "Send failed", "err", err)
+			slog.ErrorContext(stream.Context(), "Send failed", "err", err, "streamid", streamID, "sequenceNumber", sequenceNumber)
 		}
 	}
 

--- a/pkg/proto/configuration/bb_portal/BUILD.bazel
+++ b/pkg/proto/configuration/bb_portal/BUILD.bazel
@@ -27,7 +27,14 @@ go_proto_library(
 
 go_library(
     name = "bb_portal",
-    embed = [":bb_portal_go_proto"],
+    srcs = ["bb_portal.pb.go"],
     importpath = "github.com/buildbarn/bb-portal/pkg/proto/configuration/bb_portal",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/global",
+        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/grpc",
+        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/http",
+        "@org_golang_google_protobuf//reflect/protoreflect",
+        "@org_golang_google_protobuf//runtime/protoimpl",
+    ],
 )

--- a/pkg/proto/configuration/bb_portal/BUILD.bazel
+++ b/pkg/proto/configuration/bb_portal/BUILD.bazel
@@ -27,14 +27,7 @@ go_proto_library(
 
 go_library(
     name = "bb_portal",
-    srcs = ["bb_portal.pb.go"],
+    embed = [":bb_portal_go_proto"],
     importpath = "github.com/buildbarn/bb-portal/pkg/proto/configuration/bb_portal",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/global",
-        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/grpc",
-        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/http",
-        "@org_golang_google_protobuf//reflect/protoreflect",
-        "@org_golang_google_protobuf//runtime/protoimpl",
-    ],
 )


### PR DESCRIPTION
Currently, when you have a large build that takes severals seconds to save to the database, the process can fail to save if the client uses the `--bes_upload_mode=fully_async` [flag](https://bazel.build/reference/command-line-reference#flag--bes_upload_mode) 

This flag causes the client to send a graceful shutdown upon completion of transmission w/out waiting for an acknowledgment from the server.  If the database process isn't done saving before this shutdown is received, the context is destroyed and the save fails (see below)

![image](https://github.com/user-attachments/assets/58cfa13b-6179-4226-a3f2-14a0e9a7a225)

This also causes issues when the server tries to acknowledge requests 

![image](https://github.com/user-attachments/assets/a0313c33-4e16-4c2c-9d65-a3fe9b7a2752)

To address this, we can push the database save to a background process and let it finish in its own time, and we can ignore send errors when the client gracefully terminated the connection. (i think...? its not like we were doing anything but logging them anyway so....). 

- improve database save functionality to be more robust and store as much of an invocation as it can
- remove fk restraint on eventFile url, fix event file url formatting
- push db save to a background process
- remove caching for bazel invocations table view
- update make lint