### PR TITLE
finish processing checks

### DIFF
--- a/pkg/summary/summarizer.go
+++ b/pkg/summary/summarizer.go
@@ -84,6 +84,19 @@ func (s Summarizer) summarize(it *events.BuildEventIterator) (*Summary, error) {
 func (s Summarizer) FinishProcessing() (*Summary, error) {
 	// If problems are ignored for the exit code, return immediately.
 	slog.Debug("processing", "err", "none")
+
+	if s.summary.EndedAt == nil {
+		now := time.Now()
+		s.summary.EndedAt = &now
+	}
+
+	if s.summary.ExitCode == nil {
+		s.summary.ExitCode = &ExitCode{
+			Code: 1000,
+			Name: "UNKNOWN",
+		}
+	}
+
 	if !shouldIgnoreProblems(s.summary.ExitCode) {
 		slog.Debug("problems found", "err", "none")
 		// Add any detected test problems.


### PR DESCRIPTION
There are times when you never receive a build finished message for an invocation, for example when you pass an incorrect build option

```sh
bazel test //... --a_erroneous_option_flag=problems
```
This was causing corrupted database issues that lead to a broken bazel invocations table view

![image](https://github.com/user-attachments/assets/0307acdb-0574-4661-925f-7c9f6912a866)

This just adds some null checking and prevents this issue so that the invocations view displays correctly and the problems tab is also populated for these types of requests.
![image](https://github.com/user-attachments/assets/afe24137-3762-4295-8003-11f780994fc3)
