### PR TITLE
drop the index on migration when using postgres db backend

### DIFF
--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -94,7 +94,6 @@ func main() {
 				return util.StatusWrapf(err, "Failed to run schema migration")
 			}
 		} else {
-
 			if err = dbClient.Schema.Create(context.Background(), migrate.WithGlobalUniqueID(true)); err != nil {
 				return util.StatusWrapf(err, "Failed to run schema migration")
 			}

--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -88,8 +88,16 @@ func main() {
 		if err != nil {
 			return util.StatusWrapf(err, "Failed to open ent client")
 		}
-		if err = dbClient.Schema.Create(context.Background(), migrate.WithGlobalUniqueID(true)); err != nil {
-			return util.StatusWrapf(err, "Failed to run schema migration")
+
+		if *dsDriver == "pgx" {
+			if err = dbClient.Schema.Create(context.Background(), migrate.WithGlobalUniqueID(true), migrate.WithDropIndex(true)); err != nil {
+				return util.StatusWrapf(err, "Failed to run schema migration")
+			}
+		} else {
+
+			if err = dbClient.Schema.Create(context.Background(), migrate.WithGlobalUniqueID(true)); err != nil {
+				return util.StatusWrapf(err, "Failed to run schema migration")
+			}
 		}
 
 		blobArchiver := processing.NewBlobMultiArchiver()


### PR DESCRIPTION
ran into an issue when running migrations on a postgres database backend.  The driver complained about already existing indexes.  This PR will just run the migration with the setting enabled to automatically drop indexes for postgres.

i doubt dropping the index on migration would be problematic for the sqllite database, but I split it out anyway.