### PR TITLE
address performance issues w/passrate

### DIFF
--- a/config/portal.jsonnet
+++ b/config/portal.jsonnet
@@ -7,5 +7,6 @@
   grpcServers: [{
     listenAddresses: [':8082'],
     authenticationPolicy: { allow: {} },
+    maximumReceivedMessageSizeBytes: 10*1024*1024
   }],
 }

--- a/frontend/src/app/targets/page.tsx
+++ b/frontend/src/app/targets/page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Content from '@/components/Content';
 import PortalCard from '@/components/PortalCard';
-import { Space } from 'antd';
+import { Alert, Space } from 'antd';
 import { DeploymentUnitOutlined } from '@ant-design/icons';
 import TargetGrid from '@/components/Targets/TargetGrid';
 
@@ -14,7 +14,12 @@ const Page: React.FC = () => {
                 <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
                     <PortalCard
                         icon={<DeploymentUnitOutlined />}
-                        titleBits={[<span key="title">Targets Overview</span>]}>
+                        extraBits={[<Alert
+                            showIcon
+                            message = "Search by label to further refine your result"
+                            type = "info"
+                          />]}
+                        titleBits={[<span key="title">Targets Overview  </span>]}>
                         <TargetGrid />
                     </PortalCard>
                 </Space >

--- a/frontend/src/app/tests/page.tsx
+++ b/frontend/src/app/tests/page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Content from '@/components/Content';
 import PortalCard from '@/components/PortalCard';
-import { Space } from 'antd';
+import { Alert, Space } from 'antd';
 import { ExperimentFilled } from '@ant-design/icons';
 import TestGrid from '@/components/TestGrid';
 
@@ -14,6 +14,11 @@ const Page: React.FC = () => {
                 <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
                     <PortalCard
                         icon={<ExperimentFilled />}
+                        extraBits={[<Alert
+                            showIcon
+                            message = "Search by label to further refine your result"
+                            type = "info"
+                          />]}
                         titleBits={[<span key="title">Tests Overview</span>]}>
                         <TestGrid />
                     </PortalCard>

--- a/frontend/src/components/TestGrid/index.tsx
+++ b/frontend/src/components/TestGrid/index.tsx
@@ -40,7 +40,7 @@ interface TestGridRowDataType {
   status: TestStatusType[];
 }
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 20
 const columns: TableColumnsType<TestGridRowDataType> = [
   {
     title: "Label",
@@ -80,21 +80,15 @@ const columns: TableColumnsType<TestGridRowDataType> = [
     render: (_, record) => <span className={styles.numberFormat}>{record.total_count}</span>,
     //sorter: (a, b) => a.total_count - b.total_count,
   },
-  {
-    title: "Pass Rate",
-    dataIndex: "pass_rate",
-    //sorter: (a, b) => a.pass_rate - b.pass_rate,
-    render: (_, record) => <span className={styles.numberFormat}> {(record.pass_rate * 100).toFixed(2)}%</span>
-  }
 ]
 
 const TestGrid: React.FC<Props> = () => {
 
-  const [variables, setVariables] = useState<GetTestsWithOffsetQueryVariables>({})
+  const [variables, setVariables] = useState<GetTestsWithOffsetQueryVariables>({ limit:  PAGE_SIZE})
 
   const { loading: labelLoading, data: labelData, previousData: labelPreviousData, error: labelError } = useQuery(GET_TEST_GRID_DATA, {
     variables: variables,
-    fetchPolicy: 'cache-and-network',
+    pollInterval: 300000
   });
 
   const data = labelLoading ? labelPreviousData : labelData;
@@ -137,12 +131,6 @@ const TestGrid: React.FC<Props> = () => {
   return (
     <Space direction="vertical" size="middle" style={{ display: 'flex' }}>
       <Row>
-        <Space size="large">
-          <Statistic title="Test Targets" value={totalCnt} formatter={formatter} />
-        </Space>
-      </Row>
-
-      <Row>
         <Table<TestGridRowDataType>
           columns={columns}
           loading={labelLoading}
@@ -156,10 +144,11 @@ const TestGrid: React.FC<Props> = () => {
             ),
             rowExpandable: (_) => true,
           }}
-          pagination={{
-            total: totalCnt,
-            showSizeChanger: false,
-          }}
+          pagination = {false}
+          // pagination={{
+          //   total: totalCnt,
+          //   showSizeChanger: false,
+          // }}
           dataSource={result} />
       </Row>
     </Space>

--- a/internal/graphql/custom.resolvers.go
+++ b/internal/graphql/custom.resolvers.go
@@ -319,7 +319,7 @@ func (r *queryResolver) GetTargetPassAggregation(ctx context.Context, label *str
 
 // GetTestsWithOffset is the resolver for the getTestsWithOffset field.
 func (r *queryResolver) GetTestsWithOffset(ctx context.Context, label *string, offset, limit *int, sortBy, direction *string) (*model.TestGridResult, error) {
-	maxLimit := 10000
+	maxLimit := 100
 	take := 10
 	skip := 0
 	if limit != nil {
@@ -331,18 +331,9 @@ func (r *queryResolver) GetTestsWithOffset(ctx context.Context, label *string, o
 	if offset != nil {
 		skip = *offset
 	}
-	orderBy := "first_seen"
-	if sortBy != nil {
-		orderBy = *sortBy
-	}
 
 	var result []*model.TestGridRow
 	query := r.client.TestCollection.Query()
-
-	switch orderBy {
-	case "first_seen":
-		query = query.Order(testcollection.ByFirstSeen())
-	}
 
 	if label != nil && *label != "" {
 		query = query.Where(testcollection.LabelContains(*label))
@@ -361,29 +352,7 @@ func (r *queryResolver) GetTestsWithOffset(ctx context.Context, label *string, o
 	if err != nil {
 		return nil, err
 	}
-	for _, item := range result {
-		lbl := *item.Label
-		cnt := *item.Count
-		passes, err := r.client.TestCollection.Query().
-			Where(testcollection.
-				And(testcollection.LabelEQ(lbl),
-					testcollection.OverallStatusEQ(testcollection.OverallStatusPASSED))).
-			Count(ctx)
-		if err != nil {
-			return nil, err
-		}
-		passRate := float64(passes / cnt)
-		item.PassRate = &passRate
-	}
-	l := r.client.TestCollection.Query()
-	if label != nil && *label != "" {
-		l = l.Where(testcollection.LabelContains(*label))
-	}
-	labels, err := l.GroupBy(testcollection.FieldLabel).Strings(ctx)
-	if err != nil {
-		return nil, err
-	}
-	totalCount := len(labels)
+	totalCount := 0
 	response := &model.TestGridResult{
 		Result: result,
 		Total:  &totalCount,
@@ -393,7 +362,7 @@ func (r *queryResolver) GetTestsWithOffset(ctx context.Context, label *string, o
 
 // GetTargetsWithOffset is the resolver for the GetTargetsWithOffset field.
 func (r *queryResolver) GetTargetsWithOffset(ctx context.Context, label *string, offset, limit *int, sortBy, direction *string) (*model.TargetGridResult, error) {
-	maxLimit := 10000
+	maxLimit := 100
 	take := 10
 	skip := 0
 	if limit != nil {
@@ -405,18 +374,9 @@ func (r *queryResolver) GetTargetsWithOffset(ctx context.Context, label *string,
 	if offset != nil {
 		skip = *offset
 	}
-	orderBy := "first_seen"
-	if sortBy != nil {
-		orderBy = *sortBy
-	}
 
 	var result []*model.TargetGridRow
 	query := r.client.TargetPair.Query()
-
-	switch orderBy {
-	case "duration":
-		query = query.Order(targetpair.ByDurationInMs())
-	}
 
 	if label != nil && *label != "" {
 		query = query.Where(targetpair.LabelContains(*label))
@@ -435,29 +395,7 @@ func (r *queryResolver) GetTargetsWithOffset(ctx context.Context, label *string,
 	if err != nil {
 		return nil, err
 	}
-	for _, item := range result {
-		lbl := *item.Label
-		cnt := *item.Count
-		passes, err := r.client.TargetPair.Query().
-			Where(targetpair.
-				And(targetpair.LabelEQ(lbl),
-					targetpair.SuccessEQ(true))).
-			Count(ctx)
-		if err != nil {
-			return nil, err
-		}
-		passRate := float64(passes / cnt)
-		item.PassRate = &passRate
-	}
-	l := r.client.TargetPair.Query()
-	if label != nil && *label != "" {
-		l = l.Where(targetpair.LabelContains(*label))
-	}
-	labels, err := l.GroupBy(targetpair.FieldLabel).Strings(ctx)
-	if err != nil {
-		return nil, err
-	}
-	totalCount := len(labels)
+	totalCount := 0
 	response := &model.TargetGridResult{
 		Result: result,
 		Total:  &totalCount,


### PR DESCRIPTION
when running in an environment where target entries scale and become very large, the pass rate functionality can cause the targets and tests views to become slow and unresponsive.  to address this issue, i'm removing pagination and pass rate from these views and adjusting the backend queries respectively to see if this improves performance enough to make the application more responsive.  I'm also adjusting the cache policy from cache and network to the default and adding a long poll interval.  