### PR TITLE
fix: actionCache miss reason does NOT have an "UNKNOWN" enum at index 0

### DIFF
--- a/frontend/src/components/ActionCacheMetrics/ActionCacheMissTag.tsx
+++ b/frontend/src/components/ActionCacheMetrics/ActionCacheMissTag.tsx
@@ -13,14 +13,13 @@ import { Tag } from 'antd';
 import themeStyles from '@/theme/theme.module.css';
 
 export const ALL_STATUS_VALUES = [
-    'UNKNOWN',
     'DIFFERENT_ACTION_KEY',
     'DIFFERENT_DEPS',
     'DIFFERENT_ENVIRONMENT',
     'DIFFERENT_FILES',
     'CORRUPTED_CACHE_ENTRY',
     'NOT_CACHED',
-
+    'UNCONDITIONAL_EXECUTION',
 ] as const;
 export type MissDetailTuple = typeof ALL_STATUS_VALUES;
 export type MissDetailEnum = MissDetailTuple[number];
@@ -30,11 +29,6 @@ interface Props {
 }
 
 const STATUS_TAGS: { [key in MissDetailEnum]: React.ReactNode } = {
-    UNKNOWN: (
-        <Tag icon={<QuestionCircleFilled />} color="default" className={themeStyles.tag}>
-            <span className={themeStyles.tagContent}>Unknown</span>
-        </Tag>
-    ),
     DIFFERENT_ACTION_KEY: (
         <Tag icon={<KeyOutlined />} color="blue" className={themeStyles.tag}>
             <span className={themeStyles.tagContent}>Different Action Key</span>
@@ -65,7 +59,11 @@ const STATUS_TAGS: { [key in MissDetailEnum]: React.ReactNode } = {
             <span className={themeStyles.tagContent}>Not Cached</span>
         </Tag>
     ),
-
+    UNCONDITIONAL_EXECUTION: (
+        <Tag icon={<MinusCircleFilled />} color="green" className={themeStyles.tag}>
+            <span className={themeStyles.tagContent}>Unconditional Execution</span>
+        </Tag>
+    ),
 };
 
 const MissDetailTag: React.FC<Props> = ({ status }) => {

--- a/frontend/src/components/ActionCacheMetrics/ActionCacheMissTag.tsx
+++ b/frontend/src/components/ActionCacheMetrics/ActionCacheMissTag.tsx
@@ -13,6 +13,7 @@ import { Tag } from 'antd';
 import themeStyles from '@/theme/theme.module.css';
 
 export const ALL_STATUS_VALUES = [
+    'UNKNOWN',
     'DIFFERENT_ACTION_KEY',
     'DIFFERENT_DEPS',
     'DIFFERENT_ENVIRONMENT',
@@ -29,6 +30,11 @@ interface Props {
 }
 
 const STATUS_TAGS: { [key in MissDetailEnum]: React.ReactNode } = {
+    UNKNOWN: (
+        <Tag icon={<QuestionCircleFilled />} color="default" className={themeStyles.tag}>
+            <span className={themeStyles.tagContent}>Unknown</span>
+        </Tag>
+    ),
     DIFFERENT_ACTION_KEY: (
         <Tag icon={<KeyOutlined />} color="blue" className={themeStyles.tag}>
             <span className={themeStyles.tagContent}>Different Action Key</span>

--- a/frontend/src/components/ActionCacheMetrics/index.module.css
+++ b/frontend/src/components/ActionCacheMetrics/index.module.css
@@ -25,3 +25,7 @@
 .ac-miss-detail-NOT_CACHED {
     color: "#ffbd33"
 }
+
+.ac-miss-detail-UNCONDITIONAL_EXECUTION {
+    color: "#008000"
+}

--- a/frontend/src/components/ActionCacheMetrics/index.tsx
+++ b/frontend/src/components/ActionCacheMetrics/index.tsx
@@ -24,6 +24,7 @@ const formatter: StatisticProps['formatter'] = (value) => (
 
 var ac_colors =
     [
+        "grey",     //unknown
         "blue",     //different action key
         "pink",     //different deps
         "purple",   //different env

--- a/frontend/src/components/ActionCacheMetrics/index.tsx
+++ b/frontend/src/components/ActionCacheMetrics/index.tsx
@@ -24,13 +24,13 @@ const formatter: StatisticProps['formatter'] = (value) => (
 
 var ac_colors =
     [
-        "grey",     //unknown
         "blue",     //different action key
         "pink",     //different deps
         "purple",   //different env
         "cyan",     //diff files
         "orange",   //corrupted cache entry
-        "red"]      //not cached
+        "red",      //not cached
+        "green"]    //unconditional execution
 
 const ac_columns: TableColumnsType<MissDetailDisplayDataType> = [
     {

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -48,7 +48,6 @@ func (r MissReason) EnumIndex() int32 {
 // String Enum helper method.
 func (r MissReason) String() string {
 	return [...]string{
-		"UNKNOWN",
 		"DIFFERENT_ACTION_KEY",
 		"DIFFERENT_DEPS",
 		"DIFFERENT_ENVIRONMENT",


### PR DESCRIPTION
The `MissReason` enum doesn't align with the missReason() label.

I also added "UNCONDITIONAL_EXECUTION" enum consistently (Green for the UI)