### PR TITLE
fix container registry

### DIFF
--- a/patches/com_buildbarn_bb_storage/base_image.diff
+++ b/patches/com_buildbarn_bb_storage/base_image.diff
@@ -44,6 +44,6 @@ index e4aa679..4900487 100644
          name = name,
          image = image,
 -        repository = "ghcr.io/buildbarn/" + component,
-+        repository = "artifactory.stackav.io/docker/buildbarn/eie/" + component + "-backend",
++        repository = "ghcr.io/buildbarn/" + component + "-backend",
          remote_tags = "@com_github_buildbarn_bb_storage//tools:stamped_tags",
      )


### PR DESCRIPTION
accidently left a reference to private container registry used for testing.  reverting