### PR TITLE
Disable stale time for operations queries

### DIFF
--- a/frontend/src/components/OperationDetails/index.tsx
+++ b/frontend/src/components/OperationDetails/index.tsx
@@ -40,6 +40,7 @@ const OperationDetails: React.FC<Props> = ({ label }) => {
     queryFn: buildQueueStateClient.getOperation.bind(window, {
       operationName: label,
     }),
+    staleTime: Number.POSITIVE_INFINITY,
   });
 
   if (isError) {

--- a/frontend/src/components/OperationsGrid/index.tsx
+++ b/frontend/src/components/OperationsGrid/index.tsx
@@ -35,6 +35,7 @@ const OperationsTable: React.FC = () => {
       pageSize: PAGE_SIZE,
       filterInvocationId: getSerializedFilterInvocationId(filterInvocationId),
     }),
+    staleTime: Number.POSITIVE_INFINITY,
   });
 
   let emptyText = "No active operations";


### PR DESCRIPTION
Related to the discussion in #91

This makes sure that the operations table and the operations details view don't automatically refresh. Since the data is temporary, a refresh will cause the content to disappear. The automatic refresh was not intentional but instead the default behaviour of [Tanstack Query](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults).