### PR TITLE
Fix operations count not showing correctly

### DIFF
--- a/frontend/src/components/SchedulerGrid/index.tsx
+++ b/frontend/src/components/SchedulerGrid/index.tsx
@@ -1,6 +1,6 @@
 import { useGrpcClients } from "@/context/GrpcClientsContext";
 import { useQuery } from "@tanstack/react-query";
-import { Row, Space, Statistic, Typography } from "antd";
+import { Row, Skeleton, Space, Statistic, Typography } from "antd";
 import type React from "react";
 import PlatformQueuesTable from "../PlatformQueuesTable";
 import PortalAlert from "../PortalAlert";
@@ -8,33 +8,46 @@ import PortalAlert from "../PortalAlert";
 const SchedulerGrid: React.FC = () => {
   const { buildQueueStateClient } = useGrpcClients();
 
-  const { data, isError, error } = useQuery({
+  const { data, isError, error, isPending } = useQuery({
     queryKey: ["listOperations"],
     queryFn: buildQueueStateClient.listOperations.bind(window, {}),
   });
 
+  const totalNumberOfOperaionsDisplay = () => {
+    if (isError) {
+      return (
+        <PortalAlert
+          className="error"
+          message={
+            <>
+              <Typography.Text>
+                There was a problem communicating with the backend server:
+              </Typography.Text>
+              <pre>{String(error)}</pre>
+            </>
+          }
+        />
+      );
+    }
+    if (isPending) {
+      return (
+        <Space direction="vertical" size={9.5}>
+          <Skeleton.Node active style={{ width: 180, height: 16 }} />
+          <Skeleton.Node active style={{ width: 180, height: 32 }} />
+        </Space>
+      );
+    }
+    return (
+      <Statistic
+        title="Total number of operations"
+        value={data.paginationInfo?.totalEntries}
+      />
+    );
+  };
+
   return (
     <Space direction="vertical" size="middle" style={{ display: "flex" }}>
-      <Row>
-        {isError ? (
-          <PortalAlert
-            className="error"
-            message={
-              <>
-                <Typography.Text>
-                  There was a problem communicating with the backend server:
-                </Typography.Text>
-                <pre>{String(error)}</pre>
-              </>
-            }
-          />
-        ) : (
-          <Statistic
-            title="Total number of operations"
-            value={data?.paginationInfo?.totalEntries}
-          />
-        )}
-      </Row>
+      <Row>{totalNumberOfOperaionsDisplay()}</Row>
       <Row>
         <PlatformQueuesTable />
       </Row>


### PR DESCRIPTION
The design of `buildqueuestateproxy` is to only show content with instance names that the user is allowed to see, as specified by the `instanceNameAuthorizer`. The pagination info was intentionally set to 0 to now disclose information  about the part of the system that the user should not have access to. This caused to the total operations count to stop working.

This PR fixes the operations count by fetching all operations from the scheduler and recreating the pagination info based on the operations that the user is allowed to see.

Fixes #94