### PR TITLE
Allow empty instancenames

### DIFF
--- a/frontend/src/components/OperationsGrid/utils.ts
+++ b/frontend/src/components/OperationsGrid/utils.ts
@@ -7,18 +7,18 @@ export const operationsStateToActionPageUrl = (
   const instanceNamePrefix =
     operation.invocationName?.sizeClassQueueName?.platformQueueName
       ?.instanceNamePrefix;
+  const instanceNameSuffix = operation.instanceNameSuffix;
   const digestFunction = digestFunctionValueToString(operation.digestFunction);
   const actionDigestHash = operation.actionDigest?.hash;
   const actionDigestSizeBytes = operation.actionDigest?.sizeBytes;
 
-  if (
-    !instanceNamePrefix ||
-    !digestFunction ||
-    !actionDigestHash ||
-    !actionDigestSizeBytes
-  ) {
+  if (!digestFunction || !actionDigestHash || !actionDigestSizeBytes) {
     return undefined;
   }
 
-  return `/browser/${instanceNamePrefix}/blobs/${digestFunction}/action/${actionDigestHash}-${actionDigestSizeBytes}`;
+  let url = "/browser";
+  if (instanceNamePrefix) url += `/${instanceNamePrefix}`;
+  if (instanceNameSuffix) url += `/${instanceNameSuffix}`;
+  url += `/blobs/${digestFunction}/action/${actionDigestHash}-${actionDigestSizeBytes}`;
+  return url;
 };

--- a/frontend/src/utils/bloomFilter.test.ts
+++ b/frontend/src/utils/bloomFilter.test.ts
@@ -79,7 +79,7 @@ test("generateFileSystemReferenceQueryParams", () => {
     }),
   ).toEqual({
     fileSystemAccessProfile:
-      "%7B%22digest%22%3A%7B%22hash%22%3A%2201234%22%2C%22sizeBytes%22%3A%22999%22%7D%2C%22pathHashesBaseHash%22%3A%2256789%22%7D",
+      '{"digest":{"hash":"01234","sizeBytes":"999"},"pathHashesBaseHash":"56789"}',
   });
 });
 

--- a/frontend/src/utils/parseBrowserPageSlug.test.ts
+++ b/frontend/src/utils/parseBrowserPageSlug.test.ts
@@ -28,16 +28,6 @@ describe("parseBrowserPageSlug", () => {
     expect(result).toBeUndefined();
   });
 
-  it("should return undefined if instanceName is empty", () => {
-    const result = parseBrowserPageSlug([
-      "blobs",
-      "sha256",
-      "action",
-      "hash-size",
-    ]);
-    expect(result).toBeUndefined();
-  });
-
   it("should return undefined if browserPageType is undefined", () => {
     const result = parseBrowserPageSlug([
       "instance",
@@ -76,6 +66,22 @@ describe("parseBrowserPageSlug", () => {
       browserPageType: "action",
       digest: { hash: "hash", sizeBytes: "size" },
       otherParams: ["other", "params"],
+    });
+  });
+
+  it("should parse valid slug without instance name", () => {
+    const result = parseBrowserPageSlug([
+      "blobs",
+      "sha256",
+      "action",
+      "hash-size",
+    ]);
+    expect(result).toEqual({
+      instanceName: "",
+      digestFunction: 1,
+      browserPageType: "action",
+      digest: { hash: "hash", sizeBytes: "size" },
+      otherParams: [],
     });
   });
 

--- a/frontend/src/utils/parseBrowserPageSlug.ts
+++ b/frontend/src/utils/parseBrowserPageSlug.ts
@@ -16,11 +16,7 @@ export const parseBrowserPageSlug = (
   const digestFunction = digestFunctionValueFromString(slug[blobIndex + 1]);
   const browserPageType = getBrowserPageTypeFromString(slug[blobIndex + 2]);
 
-  if (
-    instanceName === "" ||
-    digestFunction === undefined ||
-    browserPageType === undefined
-  ) {
+  if (digestFunction === undefined || browserPageType === undefined) {
     return undefined;
   }
 

--- a/internal/api/grpcweb/actioncacheproxy/server.go
+++ b/internal/api/grpcweb/actioncacheproxy/server.go
@@ -27,7 +27,7 @@ func (s *ActionCacheServerImpl) GetActionResult(ctx context.Context, req *remote
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request")
 	}
 
-	if !grpcweb.IsInstanceNamePrefixAllowed(ctx, s.authorizer, req.InstanceName) {
+	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
 		return nil, status.Errorf(codes.NotFound, "Not found")
 	}
 

--- a/internal/api/grpcweb/buildqueuestateproxy/server.go
+++ b/internal/api/grpcweb/buildqueuestateproxy/server.go
@@ -33,7 +33,7 @@ func (s *BuildQueueStateServerImpl) GetOperation(ctx context.Context, req *build
 
 	platformQueueName := response.GetOperation().GetInvocationName().GetSizeClassQueueName().GetPlatformQueueName()
 
-	if platformQueueName == nil || !grpcweb.IsInstanceNamePrefixAllowed(ctx, s.authorizer, platformQueueName.InstanceNamePrefix) {
+	if platformQueueName == nil || !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, platformQueueName.InstanceNamePrefix) {
 		return nil, status.Errorf(codes.NotFound, "Operation was not found")
 	}
 
@@ -97,7 +97,7 @@ func (s *BuildQueueStateServerImpl) ListWorkers(ctx context.Context, req *buildq
 		return nil, err
 	}
 
-	if !grpcweb.IsInstanceNamePrefixAllowed(ctx, s.authorizer, instanceNamePrefix) {
+	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, instanceNamePrefix) {
 		return nil, status.Errorf(codes.PermissionDenied, "Not allowed to list workers for instance name prefix %s", instanceNamePrefix)
 	}
 	return s.client.ListWorkers(ctx, req)
@@ -131,7 +131,7 @@ func filterPlatormQueues(ctx context.Context, response *buildqueuestate.ListPlat
 
 		name := queue.GetName()
 
-		if name != nil && grpcweb.IsInstanceNamePrefixAllowed(ctx, authorizer, name.InstanceNamePrefix) {
+		if name != nil && grpcweb.IsInstanceNameAllowed(ctx, authorizer, name.InstanceNamePrefix) {
 			allowedQueues = append(allowedQueues, queue)
 		}
 	}
@@ -146,7 +146,7 @@ func filterOperations(ctx context.Context, response *buildqueuestate.ListOperati
 
 		platformQueueName := operation.GetInvocationName().GetSizeClassQueueName().GetPlatformQueueName()
 
-		if platformQueueName != nil && grpcweb.IsInstanceNamePrefixAllowed(ctx, authorizer, platformQueueName.InstanceNamePrefix) {
+		if platformQueueName != nil && grpcweb.IsInstanceNameAllowed(ctx, authorizer, platformQueueName.InstanceNamePrefix) {
 			allowedOperations = append(allowedOperations, operation)
 		}
 	}

--- a/internal/api/grpcweb/casproxy/server.go
+++ b/internal/api/grpcweb/casproxy/server.go
@@ -30,7 +30,7 @@ func (s *CasServerImpl) Read(req *bytestream.ReadRequest, stream bytestream.Byte
 	}
 
 	instanceName := getInstanceName(req.ResourceName)
-	if !grpcweb.IsInstanceNamePrefixAllowed(stream.Context(), s.authorizer, instanceName) {
+	if !grpcweb.IsInstanceNameAllowed(stream.Context(), s.authorizer, instanceName) {
 		return status.Errorf(codes.PermissionDenied, "Not authorized")
 	}
 

--- a/internal/api/grpcweb/common.go
+++ b/internal/api/grpcweb/common.go
@@ -8,10 +8,10 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/digest"
 )
 
-// IsInstanceNamePrefixAllowed checks whether the given instance name prefix is
+// IsInstanceNameAllowed checks whether the given instance name is
 // allowed by the authorizer.
-func IsInstanceNamePrefixAllowed(ctx context.Context, authorizer auth.Authorizer, instanceNamePrefix string) bool {
-	instanceName, err := digest.NewInstanceName(instanceNamePrefix)
+func IsInstanceNameAllowed(ctx context.Context, authorizer auth.Authorizer, instanceNameString string) bool {
+	instanceName, err := digest.NewInstanceName(instanceNameString)
 	if err != nil {
 		log.Println("Error parsing instance name from operation: ", err)
 		return false

--- a/internal/api/grpcweb/common_test.go
+++ b/internal/api/grpcweb/common_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestIsInstanceNamePrefixAllowed(t *testing.T) {
+func TestIsInstanceNameAllowed(t *testing.T) {
 	a := auth.NewJMESPathExpressionAuthorizer(
 		jmespath.MustCompile("contains(authenticationMetadata.private.permittedInstanceNames, instanceName) || instanceName == ''"),
 	)
@@ -29,22 +29,22 @@ func TestIsInstanceNamePrefixAllowed(t *testing.T) {
 	}))
 
 	t.Run("ValidInstanceNames", func(t *testing.T) {
-		if !IsInstanceNamePrefixAllowed(ctx, a, "") {
+		if !IsInstanceNameAllowed(ctx, a, "") {
 			t.Error("Expected empty instance name to be allowed")
 		}
-		if !IsInstanceNamePrefixAllowed(ctx, a, "allowed") {
+		if !IsInstanceNameAllowed(ctx, a, "allowed") {
 			t.Error("Expected instance name to be allowed")
 		}
-		if !IsInstanceNamePrefixAllowed(ctx, a, "alsoAllowed") {
+		if !IsInstanceNameAllowed(ctx, a, "alsoAllowed") {
 			t.Error("Expected instance name to be allowed")
 		}
 	})
 
 	t.Run("InvalidInstanceNames", func(t *testing.T) {
-		if IsInstanceNamePrefixAllowed(ctx, a, "forbidden") {
+		if IsInstanceNameAllowed(ctx, a, "forbidden") {
 			t.Error("Expected instance name to be forbidden")
 		}
-		if IsInstanceNamePrefixAllowed(ctx, a, "allowed/") {
+		if IsInstanceNameAllowed(ctx, a, "allowed/") {
 			t.Error("Expected instance name to be forbidden")
 		}
 	})

--- a/internal/api/grpcweb/fsacproxy/server.go
+++ b/internal/api/grpcweb/fsacproxy/server.go
@@ -28,7 +28,7 @@ func (s *FsacServerImpl) GetFileSystemAccessProfile(ctx context.Context, req *fs
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request")
 	}
 
-	if !grpcweb.IsInstanceNamePrefixAllowed(ctx, s.authorizer, req.InstanceName) {
+	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
 		return nil, status.Errorf(codes.PermissionDenied, "Not authorized")
 	}
 	return s.client.GetFileSystemAccessProfile(ctx, req)

--- a/internal/api/grpcweb/isccproxy/server.go
+++ b/internal/api/grpcweb/isccproxy/server.go
@@ -28,7 +28,7 @@ func (s *IsccServerImpl) GetPreviousExecutionStats(ctx context.Context, req *isc
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request")
 	}
 
-	if !grpcweb.IsInstanceNamePrefixAllowed(ctx, s.authorizer, req.InstanceName) {
+	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
 		return nil, status.Errorf(codes.PermissionDenied, "Not authorized")
 	}
 	return s.client.GetPreviousExecutionStats(ctx, req)


### PR DESCRIPTION
Makes it possible to use bb-portal with an empty instance name. 

- Rewrite the component that generates links to the browser page to not reject an empty `instanceNamePrefix` and also include the `instanceNameSuffix` in the url.
- Allow for empty `instanceName`s in the url.  
- Rename `IsInstanceNamePrefixAllowed` -> `IsInstanceNameAllowed` to better reflect that it does not only operate on prefixes.
- Fix an outdated unrelated test

Closes #95