### PR TITLE
Enable refetching on mount for BrowserDirectory and Operation components

### DIFF
--- a/frontend/src/components/BrowserDirectory/index.tsx
+++ b/frontend/src/components/BrowserDirectory/index.tsx
@@ -160,6 +160,7 @@ const RecursiveDirectoryNode: React.FC<{
       directoryDigest,
     ),
     staleTime: FETCH_STALE_TIME,
+    refetchOnMount: "always",
   });
 
   // Prefetch all child directories. React-query will cache the results for us

--- a/frontend/src/components/OperationDetails/index.tsx
+++ b/frontend/src/components/OperationDetails/index.tsx
@@ -41,6 +41,7 @@ const OperationDetails: React.FC<Props> = ({ label }) => {
       operationName: label,
     }),
     staleTime: Number.POSITIVE_INFINITY,
+    refetchOnMount: "always",
   });
 
   if (isError) {

--- a/frontend/src/components/OperationsGrid/index.tsx
+++ b/frontend/src/components/OperationsGrid/index.tsx
@@ -36,6 +36,7 @@ const OperationsTable: React.FC = () => {
       filterInvocationId: getSerializedFilterInvocationId(filterInvocationId),
     }),
     staleTime: Number.POSITIVE_INFINITY,
+    refetchOnMount: "always",
   });
 
   let emptyText = "No active operations";


### PR DESCRIPTION
Makes sure that you get fresh data when you navigate away from and then back to the page (instead of only on a refresh). This applies to the operation pages, as well as the Browser Directory page