### PR TITLE
Move `internal/api/grpcweb/common.go` into its own package

### DIFF
--- a/internal/api/common/BUILD.bazel
+++ b/internal/api/common/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "grpcweb",
+    name = "common",
     srcs = ["common.go"],
-    importpath = "github.com/buildbarn/bb-portal/internal/api/grpcweb",
+    importpath = "github.com/buildbarn/bb-portal/internal/api/common",
     visibility = ["//:__subpackages__"],
     deps = [
         "@com_github_buildbarn_bb_storage//pkg/auth",
@@ -12,9 +12,9 @@ go_library(
 )
 
 go_test(
-    name = "grpcweb_test",
+    name = "common_test",
     srcs = ["common_test.go"],
-    embed = [":grpcweb"],
+    embed = [":common"],
     deps = [
         "@com_github_buildbarn_bb_storage//pkg/auth",
         "@com_github_buildbarn_bb_storage//pkg/proto/auth",

--- a/internal/api/common/common.go
+++ b/internal/api/common/common.go
@@ -1,4 +1,4 @@
-package grpcweb
+package common
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/digest"
 )
 
-// IsInstanceNameAllowed checks whether the given instance name is
-// allowed by the authorizer.
+// IsInstanceNameAllowed checks whether the given instance name is allowed by
+// the authorizer.
 func IsInstanceNameAllowed(ctx context.Context, authorizer auth.Authorizer, instanceNameString string) bool {
 	instanceName, err := digest.NewInstanceName(instanceNameString)
 	if err != nil {

--- a/internal/api/common/common_test.go
+++ b/internal/api/common/common_test.go
@@ -1,4 +1,4 @@
-package grpcweb
+package common
 
 import (
 	"context"

--- a/internal/api/grpcweb/actioncacheproxy/BUILD.bazel
+++ b/internal/api/grpcweb/actioncacheproxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbarn/bb-portal/internal/api/grpcweb/actioncacheproxy",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/api/grpcweb",
+        "//internal/api/common",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@com_github_buildbarn_bb_storage//pkg/auth",
         "@org_golang_google_grpc//codes",

--- a/internal/api/grpcweb/actioncacheproxy/server.go
+++ b/internal/api/grpcweb/actioncacheproxy/server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
-	"github.com/buildbarn/bb-portal/internal/api/grpcweb"
+	"github.com/buildbarn/bb-portal/internal/api/common"
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -27,7 +27,7 @@ func (s *ActionCacheServerImpl) GetActionResult(ctx context.Context, req *remote
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request")
 	}
 
-	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
+	if !common.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
 		return nil, status.Errorf(codes.NotFound, "Not found")
 	}
 

--- a/internal/api/grpcweb/buildqueuestateproxy/BUILD.bazel
+++ b/internal/api/grpcweb/buildqueuestateproxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbarn/bb-portal/internal/api/grpcweb/buildqueuestateproxy",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/api/grpcweb",
+        "//internal/api/common",
         "@com_github_buildbarn_bb_remote_execution//pkg/proto/buildqueuestate",
         "@com_github_buildbarn_bb_storage//pkg/auth",
         "@org_golang_google_grpc//codes",

--- a/internal/api/grpcweb/buildqueuestateproxy/server.go
+++ b/internal/api/grpcweb/buildqueuestateproxy/server.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"sort"
 
-	"github.com/buildbarn/bb-portal/internal/api/grpcweb"
+	"github.com/buildbarn/bb-portal/internal/api/common"
 	"github.com/buildbarn/bb-remote-execution/pkg/proto/buildqueuestate"
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"google.golang.org/grpc/codes"
@@ -35,7 +35,7 @@ func (s *BuildQueueStateServerImpl) GetOperation(ctx context.Context, req *build
 
 	platformQueueName := response.GetOperation().GetInvocationName().GetSizeClassQueueName().GetPlatformQueueName()
 
-	if platformQueueName == nil || !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, platformQueueName.InstanceNamePrefix) {
+	if platformQueueName == nil || !common.IsInstanceNameAllowed(ctx, s.authorizer, platformQueueName.InstanceNamePrefix) {
 		return nil, status.Errorf(codes.NotFound, "Operation was not found")
 	}
 
@@ -101,7 +101,7 @@ func (s *BuildQueueStateServerImpl) ListWorkers(ctx context.Context, req *buildq
 		return nil, err
 	}
 
-	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, instanceNamePrefix) {
+	if !common.IsInstanceNameAllowed(ctx, s.authorizer, instanceNamePrefix) {
 		return nil, status.Errorf(codes.PermissionDenied, "Not allowed to list workers for instance name prefix %s", instanceNamePrefix)
 	}
 	return s.client.ListWorkers(ctx, req)
@@ -135,7 +135,7 @@ func filterPlatormQueues(ctx context.Context, response *buildqueuestate.ListPlat
 
 		name := queue.GetName()
 
-		if name != nil && grpcweb.IsInstanceNameAllowed(ctx, authorizer, name.InstanceNamePrefix) {
+		if name != nil && common.IsInstanceNameAllowed(ctx, authorizer, name.InstanceNamePrefix) {
 			allowedQueues = append(allowedQueues, queue)
 		}
 	}
@@ -150,7 +150,7 @@ func filterOperations(ctx context.Context, response *buildqueuestate.ListOperati
 
 		platformQueueName := operation.GetInvocationName().GetSizeClassQueueName().GetPlatformQueueName()
 
-		if platformQueueName != nil && grpcweb.IsInstanceNameAllowed(ctx, authorizer, platformQueueName.InstanceNamePrefix) {
+		if platformQueueName != nil && common.IsInstanceNameAllowed(ctx, authorizer, platformQueueName.InstanceNamePrefix) {
 			allowedOperations = append(allowedOperations, operation)
 		}
 	}

--- a/internal/api/grpcweb/casproxy/BUILD.bazel
+++ b/internal/api/grpcweb/casproxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbarn/bb-portal/internal/api/grpcweb/casproxy",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/api/grpcweb",
+        "//internal/api/common",
         "@com_github_buildbarn_bb_storage//pkg/auth",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//codes",

--- a/internal/api/grpcweb/casproxy/server.go
+++ b/internal/api/grpcweb/casproxy/server.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/buildbarn/bb-portal/internal/api/grpcweb"
+	"github.com/buildbarn/bb-portal/internal/api/common"
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc/codes"
@@ -32,7 +32,7 @@ func (s *CasServerImpl) Read(req *bytestream.ReadRequest, stream bytestream.Byte
 	ctx := stream.Context()
 
 	instanceName := getInstanceName(req.ResourceName)
-	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, instanceName) {
+	if !common.IsInstanceNameAllowed(ctx, s.authorizer, instanceName) {
 		return status.Errorf(codes.PermissionDenied, "Not authorized")
 	}
 

--- a/internal/api/grpcweb/fsacproxy/BUILD.bazel
+++ b/internal/api/grpcweb/fsacproxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbarn/bb-portal/internal/api/grpcweb/fsacproxy",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/api/grpcweb",
+        "//internal/api/common",
         "@com_github_buildbarn_bb_storage//pkg/auth",
         "@com_github_buildbarn_bb_storage//pkg/proto/fsac",
         "@org_golang_google_grpc//codes",

--- a/internal/api/grpcweb/fsacproxy/server.go
+++ b/internal/api/grpcweb/fsacproxy/server.go
@@ -3,7 +3,7 @@ package fsacproxy
 import (
 	"context"
 
-	"github.com/buildbarn/bb-portal/internal/api/grpcweb"
+	"github.com/buildbarn/bb-portal/internal/api/common"
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"github.com/buildbarn/bb-storage/pkg/proto/fsac"
 	"google.golang.org/grpc/codes"
@@ -28,7 +28,7 @@ func (s *FsacServerImpl) GetFileSystemAccessProfile(ctx context.Context, req *fs
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request")
 	}
 
-	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
+	if !common.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
 		return nil, status.Errorf(codes.PermissionDenied, "Not authorized")
 	}
 	return s.client.GetFileSystemAccessProfile(ctx, req)

--- a/internal/api/grpcweb/isccproxy/BUILD.bazel
+++ b/internal/api/grpcweb/isccproxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/buildbarn/bb-portal/internal/api/grpcweb/isccproxy",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/api/grpcweb",
+        "//internal/api/common",
         "@com_github_buildbarn_bb_storage//pkg/auth",
         "@com_github_buildbarn_bb_storage//pkg/proto/iscc",
         "@org_golang_google_grpc//codes",

--- a/internal/api/grpcweb/isccproxy/server.go
+++ b/internal/api/grpcweb/isccproxy/server.go
@@ -3,7 +3,7 @@ package isccproxy
 import (
 	"context"
 
-	"github.com/buildbarn/bb-portal/internal/api/grpcweb"
+	"github.com/buildbarn/bb-portal/internal/api/common"
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"github.com/buildbarn/bb-storage/pkg/proto/iscc"
 	"google.golang.org/grpc/codes"
@@ -28,7 +28,7 @@ func (s *IsccServerImpl) GetPreviousExecutionStats(ctx context.Context, req *isc
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid request")
 	}
 
-	if !grpcweb.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
+	if !common.IsInstanceNameAllowed(ctx, s.authorizer, req.InstanceName) {
 		return nil, status.Errorf(codes.PermissionDenied, "Not authorized")
 	}
 	return s.client.GetPreviousExecutionStats(ctx, req)


### PR DESCRIPTION
`internal/api/grpcweb/common.go` is moved to `internal/api/common/common.go` to indicate that it is a common module for more than just the `grpcweb` package. This is needed in for #108 