### PR TITLE
database cleanup script

### DIFF
--- a/tools/db/BUILD.bazel
+++ b/tools/db/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@com_github_buildbarn_bb_storage//tools:container.bzl", "container_push_official", "multiarch_go_image")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "db_lib",
+    srcs = ["db_cleanup.go"],
+    importpath = "github.com/buildbarn/bb-portal/tools/db",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "db",
+    embed = [":db_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "db_test",
+    srcs = ["db_cleaup_test.go"],
+    embed = [":db_lib"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)
+
+multiarch_go_image(
+    name = "bb_portal_db_cleanup_container",
+    binary = ":db",
+)
+
+container_push_official(
+    name = "bb_portal_container_push",
+    component = "bb-portal-cleanup",
+    image = ":bb_portal_db_cleanup_container",
+)

--- a/tools/db/Dockerfile
+++ b/tools/db/Dockerfile
@@ -1,0 +1,26 @@
+# Use the official Go image as the base image
+FROM golang:1.20-alpine
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Install necessary dependencies
+RUN apk add --no-cache ca-certificates
+
+# Copy the Go script and any required files into the container
+COPY db_cleanup.go ./
+
+# Copy SSL certificates if needed
+# COPY /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Build the Go script
+RUN go build -o db_cleanup db_cleanup.go
+
+# Set environment variables (can be overridden at runtime)
+ENV BASE_URL=https://localhost:8081
+ENV HOURS_TO_SUBTRACT=120
+ENV TIMEZONE=UTC
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
+# Command to run the script
+CMD ["./db_cleanup"]

--- a/tools/db/cronjob.yml
+++ b/tools/db/cronjob.yml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bbportal-db-cleanup
+spec:
+  schedule: "*/10 * * * *"  # Runs every ten minutes
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          imagePullSecrets:
+            - name: your-private-registry-secret
+          containers:
+          - name: bbportal-db-cleanup
+            image: your.registry.io/docker/buildbarn/db-cleanup:v3
+            env:
+            - name: BASE_URL
+              value: "https://bbportal.exampleco.io"
+            - name: HOURS_TO_SUBTRACT
+              value: "1000"
+            - name: TIMEZONE
+              value: "EST"
+            - name: SSL_CERT_FILE
+              value: "/etc/ssl/certs/your-cert-bundle.crt"
+            volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs
+              readOnly: true
+          restartPolicy: OnFailure
+          volumes:
+          - name: ssl-certs
+            configMap:
+              name: your-cert-bundle.crt
+              items:
+              - key: your-cert-bundle.crt
+                path: your-cert-bundle.crt

--- a/tools/db/db_cleanup.go
+++ b/tools/db/db_cleanup.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// DeleteBuildsBeforeResponse represents the response structure for the deleteBuildsBefore mutation
+type DeleteBuildsBeforeResponse struct {
+	Data struct {
+		DeleteBuildsBefore struct {
+			Found      int  `json:"found"`
+			Deleted    int  `json:"deleted"`
+			Successful bool `json:"successful"`
+		} `json:"deleteBuildsBefore"`
+	} `json:"data"`
+}
+
+// DeleteInvocationsBeforeResponse represents the response structure for the deleteInvocationsBefore mutation
+type DeleteInvocationsBeforeResponse struct {
+	Data struct {
+		DeleteInvocationsBefore struct {
+			Found      int  `json:"found"`
+			Deleted    int  `json:"deleted"`
+			Successful bool `json:"successful"`
+		} `json:"deleteInvocationsBefore"`
+	} `json:"data"`
+}
+
+func main() {
+	baseURL := getEnv("BASE_URL", "http://localhost:8081")
+	hoursToSubtract := getEnvAsInt("HOURS_TO_SUBTRACT", 1000)
+	timezone := getEnv("TIMEZONE", "UTC")
+	sslCertFile := getEnv("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt")
+
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		fmt.Printf("Error loading timezone: %v\n", err)
+		return
+	}
+
+	now := time.Now().In(loc)
+	deleteBeforeTime := now.Add(-time.Duration(hoursToSubtract) * time.Hour)
+	formattedTime := deleteBeforeTime.Format("2006-01-02T15:04:05.000Z")
+
+	fmt.Printf("Deleting builds and invocations starting before %s\n", formattedTime)
+
+	apiURL := fmt.Sprintf("%s/graphql", baseURL)
+
+	// First query: Delete builds before the specified time
+	queryDeleteBuilds := fmt.Sprintf(`
+    mutation deleteBuildsBefore {
+        deleteBuildsBefore(time: "%s") {
+            found
+            deleted
+            successful
+        }
+    }`, formattedTime)
+
+	executeGraphQLQuery(apiURL, queryDeleteBuilds, "DeleteBuildsBeforeResponse", sslCertFile)
+
+	// Second query: Delete invocations before the specified time
+	queryDeleteInvocations := fmt.Sprintf(`
+    mutation deleteInvocationsBefore {
+        deleteInvocationsBefore(time: "%s") {
+            found
+            deleted
+            successful
+        }
+    }`, formattedTime)
+
+	executeGraphQLQuery(apiURL, queryDeleteInvocations, "DeleteInvocationsBeforeResponse", sslCertFile)
+}
+
+func executeGraphQLQuery(apiURL, query, responseType, sslCertFile string) {
+	// Determine if the URL is HTTP or HTTPS
+	var client *http.Client
+	if strings.HasPrefix(apiURL, "https://") {
+		// Load custom certificate if sslCertFile is provided
+		tlsConfig := &tls.Config{}
+		if _, err := os.Stat(sslCertFile); err == nil {
+			certPool := x509.NewCertPool()
+			certData, err := ioutil.ReadFile(sslCertFile)
+			if err != nil {
+				fmt.Printf("Error reading SSL certificate file: %v\n", err)
+				return
+			}
+			if !certPool.AppendCertsFromPEM(certData) {
+				fmt.Println("Failed to append certificates from SSL certificate file")
+				return
+			}
+			tlsConfig.RootCAs = certPool
+			fmt.Printf("Loaded SSL certificate file: %s\n", sslCertFile)
+		} else {
+			fmt.Println("SSL certificate file not found, using system certificates")
+		}
+
+		// Create HTTP client with custom TLS configuration
+		client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		}
+	} else {
+		// Create HTTP client for HTTP protocol
+		client = &http.Client{}
+	}
+
+	// Prepare the GraphQL request
+	reqBody := map[string]string{"query": query}
+	reqBodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		fmt.Printf("Error marshaling request body: %v\n", err)
+		return
+	}
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(reqBodyJSON))
+	if err != nil {
+		fmt.Printf("Error creating HTTP request: %v\n", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Execute the request
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("Error executing HTTP request: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Parse the response
+	if responseType == "DeleteBuildsBeforeResponse" {
+		var response DeleteBuildsBeforeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			fmt.Printf("Error decoding response: %v\n", err)
+			return
+		}
+		responseJSON, _ := json.MarshalIndent(response, "", "  ")
+		fmt.Println("Delete Builds Response:")
+		fmt.Println(string(responseJSON))
+	} else if responseType == "DeleteInvocationsBeforeResponse" {
+		var response DeleteInvocationsBeforeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			fmt.Printf("Error decoding response: %v\n", err)
+			return
+		}
+		responseJSON, _ := json.MarshalIndent(response, "", "  ")
+		fmt.Println("Delete Invocations Response:")
+		fmt.Println(string(responseJSON))
+	}
+}
+
+func getEnv(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
+
+func getEnvAsInt(key string, defaultValue int) int {
+	if valueStr, exists := os.LookupEnv(key); exists {
+		var value int
+		if _, err := fmt.Sscanf(valueStr, "%d", &value); err == nil {
+			return value
+		}
+	}
+	return defaultValue
+}

--- a/tools/db/db_cleaup_test.go
+++ b/tools/db/db_cleaup_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMainFunction(t *testing.T) {
+	// Mock environment variables
+	os.Setenv("BASE_URL", "http://localhost:8081")
+	os.Setenv("HOURS_TO_SUBTRACT", "120")
+	os.Setenv("TIMEZONE", "UTC")
+	os.Setenv("SSL_CERT_FILE", "/path/to/mock/cert.pem")
+
+	// Mock HTTP server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/graphql", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+
+		// Mock response for builds
+		if r.Body != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+                "data": {
+                    "deleteBuildsBefore": {
+                        "found": 10,
+                        "deleted": 8,
+                        "successful": true
+                    }
+                }
+            }`))
+		}
+	}))
+	defer mockServer.Close()
+
+	// Override BASE_URL with the mock server URL
+	os.Setenv("BASE_URL", mockServer.URL)
+
+	// Run the main function
+	main()
+
+	// Reset environment variables
+	os.Unsetenv("BASE_URL")
+	os.Unsetenv("HOURS_TO_SUBTRACT")
+	os.Unsetenv("TIMEZONE")
+	os.Unsetenv("SSL_CERT_FILE")
+}
+
+func TestExecuteGraphQLQuery(t *testing.T) {
+	// Mock environment variables
+	os.Setenv("SSL_CERT_FILE", "/path/to/mock/cert.pem")
+
+	// Mock HTTP server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/graphql", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+
+		// Mock response for invocations
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+            "data": {
+                "deleteInvocationsBefore": {
+                    "found": 5,
+                    "deleted": 4,
+                    "successful": true
+                }
+            }
+        }`))
+	}))
+	defer mockServer.Close()
+
+	// Test the executeGraphQLQuery function
+	apiURL := mockServer.URL + "/graphql"
+	query := `
+        mutation deleteInvocationsBefore {
+            deleteInvocationsBefore(time: "2025-05-01T00:00:00.000Z") {
+                found
+                deleted
+                successful
+            }
+        }`
+	sslCertFile := "/path/to/mock/cert.pem" // Add the SSL certificate file argument
+	executeGraphQLQuery(apiURL, query, "DeleteInvocationsBeforeResponse", sslCertFile)
+
+	// Reset environment variables
+	os.Unsetenv("SSL_CERT_FILE")
+}
+
+func TestGetEnv(t *testing.T) {
+	os.Setenv("TEST_KEY", "test_value")
+	assert.Equal(t, "test_value", getEnv("TEST_KEY", "default_value"))
+	assert.Equal(t, "default_value", getEnv("NON_EXISTENT_KEY", "default_value"))
+	os.Unsetenv("TEST_KEY")
+}
+
+func TestGetEnvAsInt(t *testing.T) {
+	os.Setenv("TEST_INT_KEY", "42")
+	assert.Equal(t, 42, getEnvAsInt("TEST_INT_KEY", 0))
+	assert.Equal(t, 0, getEnvAsInt("NON_EXISTENT_INT_KEY", 0))
+	os.Unsetenv("TEST_INT_KEY")
+}

--- a/tools/db/readme.md
+++ b/tools/db/readme.md
@@ -1,0 +1,101 @@
+# Database Cleanup Tool
+
+This directory contains the `db_cleanup.go` script and its associated test file, `db_cleanup_test.go` as well as a sample docker file and cronjob manifest. The tool is designed to clean up builds and invocations in the database by executing GraphQL mutations.
+
+## Files
+
+### `db_cleanup.go`
+- **Purpose**: Deletes builds and invocations from the database based on a specified time threshold.
+- **Features**:
+  - Executes two GraphQL mutations:
+    - `deleteBuildsBefore`
+    - `deleteInvocationsBefore`
+  - Supports both HTTP and HTTPS protocols.
+  - Optionally loads an SSL certificate file for HTTPS connections.
+  - Allows you to specify a configurable lookback period to control which invocations and builds to delete
+
+### `db_cleanup_test.go`
+- **Purpose**: Provides unit tests for the `db_cleanup.go` script.
+- **Features**:
+  - Mocks environment variables and HTTP responses.
+  - Tests the `executeGraphQLQuery` function for both builds and invocations.
+  - Validates SSL certificate handling.
+
+
+### `cronjob.yml`
+- **Purpose**: Sample Kubernetes cronjob manifest
+- **Features**:
+  - Schedule - adjust this as needed.  If you create a lot of invocations you probably want to run it more frequently
+  - Shows how to provide a certificate and custom environment variables to the cronjob
+
+### `Dockerfile`
+- **Purpose**: Allows you to easily build a test container for dev purposes
+- **Features**:
+  - uses alpine base image
+
+
+## Environment Variables
+
+The script relies on the following environment variables:
+
+- `BASE_URL`: The base URL of the GraphQL API (e.g., `http://localhost:8081`).
+- `HOURS_TO_SUBTRACT`: The number of hours to subtract from the current time to determine the threshold for deletion.
+- `TIMEZONE`: The timezone to use for time calculations (e.g., `UTC`).
+- `SSL_CERT_FILE`: Path to the SSL certificate file for HTTPS connections (optional).
+
+## Usage
+
+### Running the Script
+1. Set the required environment variables.
+2. Execute the script:
+
+
+### Example
+Export Environment Variables
+```sh
+export BASE_URL="https://bbportal.exampleco.io"
+export HOURS_TO_SUBTRACT="120"
+export TIMEZONE="UTC"
+export SSL_CERT_FILE="/path/to/cert.pem"
+```
+and run the script
+ ```bash
+go run db_cleanup.go
+```
+Sample Output
+```sh
+Deleting builds and invocations starting before 2025-05-01T00:00:00.000Z
+Delete Builds Response:
+{
+  "found": 10,
+  "deleted": 8,
+  "successful": true
+}
+Delete Invocations Response:
+{
+  "found": 5,
+  "deleted": 4,
+  "successful": true
+}
+```
+
+
+### Building the OCI image
+
+You can push the OCI container to your private registry if you like.
+1. First modify bb-portal/patches/com_buildbarn_bb_storage/base_image.diff to point to your private registry
+2. Make sure your logged into your private registry with `docker login your.private.registry.io`
+3. Run the following command:
+
+```sh
+bazel run --stamp //tools/db:bb_portal_container_push
+```
+
+It does some funky image tagging that doesn't work great outside of CI, but you can easily just use the sha or retag as you like.
+
+
+### Notes
+- Ensure the GraphQL API is accessible and the environment variables are correctly set.
+- For HTTPS connections, you can optionally provide a valid SSL certificate file for your private certificate authority.
+- There is a dockerfile you can use optionally use to build the with a base for dev purposes
+- Tested on postgres production database thats usually around 200GBs in size.  The sql delete queries are blocking, so you may have to adjust the frequency of your cronjob or your lookback window to find what values work best for your environment.  This also works best when you are NOT storing target data in your database as those cascading deletes can fail to work on large builds and large instances.  Its recommended that you do not collect target data for every build anyway and only do it when there is something particular you want to see and explore.


### PR DESCRIPTION
Adds a simple golang script that will clean up your database and help you manage the size. 

from the readme:
# Database Cleanup Tool

This directory contains the `db_cleanup.go` script and its associated test file, `db_cleanup_test.go` as well as a sample docker file and cronjob manifest. The tool is designed to clean up builds and invocations in the database by executing GraphQL mutations.

## Files

### `db_cleanup.go`
- **Purpose**: Deletes builds and invocations from the database based on a specified time threshold.
- **Features**:
  - Executes two GraphQL mutations:
    - `deleteBuildsBefore`
    - `deleteInvocationsBefore`
  - Supports both HTTP and HTTPS protocols.
  - Optionally loads an SSL certificate file for HTTPS connections.
  - Allows you to specify a configurable lookback period to control which invocations and builds to delete

### `db_cleanup_test.go`
- **Purpose**: Provides unit tests for the `db_cleanup.go` script.
- **Features**:
  - Mocks environment variables and HTTP responses.
  - Tests the `executeGraphQLQuery` function for both builds and invocations.
  - Validates SSL certificate handling.


### `cronjob.yml`
- **Purpose**: Sample Kubernetes cronjob manifest
- **Features**:
  - Schedule - adjust this as needed.  If you create a lot of invocations you probably want to run it more frequently
  - Shows how to provide a certificate and custom environment variables to the cronjob

### `Dockerfile`
- **Purpose**: Allows you to easily build a test container for dev purposes
- **Features**:
  - uses alpine base image


## Environment Variables

The script relies on the following environment variables:

- `BASE_URL`: The base URL of the GraphQL API (e.g., `http://localhost:8081`).
- `HOURS_TO_SUBTRACT`: The number of hours to subtract from the current time to determine the threshold for deletion.
- `TIMEZONE`: The timezone to use for time calculations (e.g., `UTC`).
- `SSL_CERT_FILE`: Path to the SSL certificate file for HTTPS connections (optional).

## Usage

### Running the Script
1. Set the required environment variables.
2. Execute the script:


### Example
Export Environment Variables
```sh
export BASE_URL="https://bbportal.exampleco.io"
export HOURS_TO_SUBTRACT="120"
export TIMEZONE="UTC"
export SSL_CERT_FILE="/path/to/cert.pem"
```
and run the script
 ```bash
go run db_cleanup.go
```
Sample Output
```sh
Deleting builds and invocations starting before 2025-05-01T00:00:00.000Z
Delete Builds Response:
{
  "found": 10,
  "deleted": 8,
  "successful": true
}
Delete Invocations Response:
{
  "found": 5,
  "deleted": 4,
  "successful": true
}
```


### Building the OCI image

You can push the OCI container to your private registry if you like.
1. First modify bb-portal/patches/com_buildbarn_bb_storage/base_image.diff to point to your private registry
2. Make sure your logged into your private registry with `docker login your.private.registry.io`
3. Run the following command:

```sh
bazel run --stamp //tools/db:bb_portal_container_push
```

It does some funky image tagging that doesn't work great outside of CI, but you can easily just use the sha or retag as you like.


### Notes
- Ensure the GraphQL API is accessible and the environment variables are correctly set.
- For HTTPS connections, you can optionally provide a valid SSL certificate file for your private certificate authority.
- There is a dockerfile you can use optionally use to build the with a base for dev purposes
- Tested on postgres production database thats usually around 200GBs in size.  The sql delete queries are blocking, so you may have to adjust the frequency of your cronjob or your lookback window to find what values work best for your environment.  This also works best when you are NOT storing target data in your database as those cascading deletes can fail to work on large builds and large instances.  Its recommended that you do not collect target data for every build anyway and only do it when there is something particular you want to see and explore.