### PR TITLE
Make frontend image tag match backend image tag

### DIFF
--- a/.github/workflows/frontend-master.yaml
+++ b/.github/workflows/frontend-master.yaml
@@ -15,10 +15,14 @@ jobs:
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u $ --password-stdin
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Set frontend image tag variables
+        run: |
+          echo "TIMESTAMP=$(TZ=UTC date --date "@$(git show -s --format=%ct HEAD)" +%Y%m%dT%H%M%SZ)" >> $GITHUB_ENV
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: frontend
           file: ./frontend/Dockerfile
           push: true
-          tags: ghcr.io/buildbarn/bb-portal-frontend:${{ github.sha }}
+          tags: ghcr.io/buildbarn/bb-portal-frontend:${{ env.TIMESTAMP }}-${{ env.SHA_SHORT }}

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -11,10 +11,14 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+      - name: Set frontend image tag variables
+        run: |
+          echo "TIMESTAMP=$(TZ=UTC date --date "@$(git show -s --format=%ct HEAD)" +%Y%m%dT%H%M%SZ)" >> $GITHUB_ENV
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Build
         uses: docker/build-push-action@v4
         with:
           context: frontend
           file: ./frontend/Dockerfile
           push: false
-          tags: ghcr.io/buildbarn/bb-portal-frontend:${{ github.sha }}
+          tags: ghcr.io/buildbarn/bb-portal-frontend:${{ env.TIMESTAMP }}-${{ env.SHA_SHORT }}


### PR DESCRIPTION
The images `bb-portal-backend` and `bb-portal-frontend` have different tags, which can make it inconvenient to match frontend and backend versions. This commit changes the frontend tag to match the backend's, as specified in [tools/workspace-status.sh](tools/workspace-status.sh).