### PR TITLE
Cleanup metrics reporting

### DIFF
--- a/cmd/bb_portal/BUILD.bazel
+++ b/cmd/bb_portal/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "@com_github_improbable_eng_grpc_web//go/grpcweb",
         "@com_github_jackc_pgx_v5//stdlib",
         "@com_github_mattn_go_sqlite3//:go-sqlite3",
-        "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_rs_cors//:cors",
         "@io_entgo_contrib//entgql",
         "@io_entgo_ent//dialect",

--- a/config/portal.jsonnet
+++ b/config/portal.jsonnet
@@ -19,6 +19,17 @@
 // do anything useful.
 
 {
+  global: {
+    diagnosticsHttpServer: {
+      httpServers: [{
+        listenAddresses: [':9980'],
+        authenticationPolicy: { allow: {} },
+      }],
+      enablePrometheus: true,
+      enablePprof: true,
+      enableActiveSpans: true,
+    },
+  },
   frontendProxyUrl: 'http://localhost:3000',
   allowedOrigins: ['http://localhost:3000'],
 

--- a/pkg/prometheus_metrics/dashboards/overview.json
+++ b/pkg/prometheus_metrics/dashboards/overview.json
@@ -1,4 +1,44 @@
 {
+  "__inputs": [],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -19,7 +59,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 673525,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -36,10 +76,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Count the number of unique test targets seen during the time period.  Does not include cached results.",
       "fieldConfig": {
         "defaults": {
@@ -77,7 +113,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -85,15 +123,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count( group (buildbarn_bb_portal_uncached_test_durations) by (Target))",
+          "expr": "count( group (buildbarn_portal_uncached_test_durations) by (Target))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -104,10 +138,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Current average across invocations",
       "fieldConfig": {
         "defaults": {
@@ -152,7 +182,9 @@
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -160,15 +192,11 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "100 * (histogram_quantile(.9, sum by (le) (rate(buildbarn_bb_portal_remote_cache_hit_rate_bucket[10m]))))",
+          "expr": "100 * (histogram_quantile(.9, sum by (le) (rate(buildbarn_portal_remote_cache_hit_rate_bucket[10m]))))",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -180,10 +208,6 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "the number of hosts sending invocations to bbportal",
       "fieldConfig": {
         "defaults": {
@@ -221,7 +245,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -229,15 +255,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count( (group( buildbarn_bb_portal_invocation_counts ) by (User)))",
+          "expr": "count( (group( buildbarn_portal_invocation_counts ) by (User)))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -248,86 +270,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
-      "description": "number of active bb-portal pods during the time period",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 3
-              },
-              {
-                "color": "red",
-                "value": 4
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 8,
-        "y": 1
-      },
-      "id": 12,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.1.4",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "count(kube_pod_info{namespace=\"swe\", pod=~\"bb-portal-.*-.*\", pod!~\"bb-portal-db-cleanup-.*\", __tenant_id__=\"swe01-qas-prod\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "# bb-portal pods",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "These build target durations took the longest to execute during the time period.  Can include tests",
       "fieldConfig": {
         "defaults": {
@@ -408,7 +350,9 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "frameIndex": 1,
@@ -420,16 +364,12 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "topk(10, buildbarn_bb_portal_slow_target_durations)",
+          "expr": "topk(10, buildbarn_portal_slow_target_durations)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -487,10 +427,6 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Count of targets seen during the time period, excludes any targets that completed with a duration of less than 2 seconds",
       "fieldConfig": {
         "defaults": {
@@ -528,7 +464,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -536,15 +474,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count( group( buildbarn_bb_portal_slow_target_durations) by (Target))",
+          "expr": "count( group( buildbarn_portal_slow_target_durations) by (Target))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -555,10 +489,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Number of host machines sending invocations to bbportal. ",
       "fieldConfig": {
         "defaults": {
@@ -600,7 +530,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -608,15 +540,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(group(buildbarn_bb_portal_invocation_counts) by (Host))",
+          "expr": "count(group(buildbarn_portal_invocation_counts) by (Host))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -627,10 +555,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Rate of tests with a failed status over a 10minute period",
       "fieldConfig": {
         "defaults": {
@@ -644,6 +568,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -705,15 +630,11 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "topk(10,rate( buildbarn_bb_portal_uncached_test_durations{Status=\"FAILED\"}[10m]))",
+          "expr": "topk(10,rate( buildbarn_portal_uncached_test_durations{Status=\"FAILED\"}[10m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -724,10 +645,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Top longest test duration executions with a status of failed",
       "fieldConfig": {
         "defaults": {
@@ -807,7 +724,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -818,15 +737,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "topk(10, buildbarn_bb_portal_uncached_test_durations{Status=\"FAILED\"})",
+          "expr": "topk(10, buildbarn_portal_uncached_test_durations{Status=\"FAILED\"})",
           "hide": true,
           "instant": false,
           "legendFormat": "__auto",
@@ -834,12 +749,8 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "topk(10, buildbarn_bb_portal_uncached_test_durations{Status=\"FAILED\"})",
+          "expr": "topk(10, buildbarn_portal_uncached_test_durations{Status=\"FAILED\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -911,10 +822,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "the rate of invocations over a 10 minute period",
       "fieldConfig": {
         "defaults": {
@@ -928,6 +835,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -989,14 +897,11 @@
           "sort": "none"
         }
       },
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "rate(buildbarn_bb_portal_invocation_counts{Host=~\"$Host\"}[10m])",
+          "expr": "rate(buildbarn_portal_invocation_counts{Host=~\"$Host\"}[10m])",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1007,10 +912,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "A count of invocations by Host",
       "fieldConfig": {
         "defaults": {
@@ -1050,7 +951,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -1061,15 +964,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_invocation_counts) by (Host)",
+          "expr": "count(buildbarn_portal_invocation_counts) by (Host)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1109,10 +1008,6 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "A count of invocations by Step Label",
       "fieldConfig": {
         "defaults": {
@@ -1131,7 +1026,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1154,7 +1050,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -1165,15 +1063,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_invocation_counts) by (StepLabel)",
+          "expr": "count(buildbarn_portal_invocation_counts) by (StepLabel)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1214,10 +1108,6 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "A count of invocations by User",
       "fieldConfig": {
         "defaults": {
@@ -1236,7 +1126,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1259,7 +1150,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -1270,15 +1163,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_invocation_counts) by (User)",
+          "expr": "count(buildbarn_portal_invocation_counts) by (User)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1329,9 +1218,9 @@
       "id": 20,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -1358,24 +1247,19 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 39,
-  "tags": ["RBE", "BB-Portal"],
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [
+    "RBE",
+    "BB-Portal"
+  ],
   "templating": {
     "list": [
       {
         "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "mimir"
-        },
+        "current": {},
         "definition": "label_values(Host)",
         "description": "Hostname",
-        "hide": 0,
         "includeAll": true,
         "label": "Host",
         "multi": true,
@@ -1388,8 +1272,6 @@
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       }
     ]
@@ -1402,6 +1284,6 @@
   "timezone": "browser",
   "title": "BB Portal - Overview",
   "uid": "cej7nflp46sxsc",
-  "version": 128,
+  "version": 1,
   "weekStart": ""
 }

--- a/pkg/prometheus_metrics/dashboards/targets.json
+++ b/pkg/prometheus_metrics/dashboards/targets.json
@@ -1,4 +1,32 @@
 {
+  "__inputs": [],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -19,10 +47,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 673528,
+  "id": null,
   "links": [],
   "panels": [
     {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -30,14 +59,11 @@
         "y": 0
       },
       "id": 7,
+      "panels": [],
       "title": "Metrics",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "A breakdown of reported build durations per top level target",
       "fieldConfig": {
         "defaults": {
@@ -51,6 +77,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 36,
             "gradientMode": "none",
@@ -102,7 +129,11 @@
       "id": 3,
       "options": {
         "legend": {
-          "calcs": ["min", "max", "mean"],
+          "calcs": [
+            "min",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -112,26 +143,19 @@
           "sort": "none"
         }
       },
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//autonomy/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//autonomy/.*\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//docs/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//docs/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -139,12 +163,8 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//examples/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//examples/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -152,12 +172,8 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//experimental/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//experimental/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -165,12 +181,8 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//firmware/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//firmware/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -178,12 +190,8 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//hardware/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//hardware/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -191,12 +199,8 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//jewels/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//jewels/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -204,12 +208,8 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//kits/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//kits/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -217,12 +217,8 @@
           "refId": "H"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//platforms/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//platforms/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -230,12 +226,8 @@
           "refId": "I"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//ros/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//ros/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -243,12 +235,8 @@
           "refId": "J"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//services/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//services/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -256,12 +244,8 @@
           "refId": "K"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//sim/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//sim/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -269,12 +253,8 @@
           "refId": "L"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//system/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//system/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -282,12 +262,8 @@
           "refId": "M"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//third_party/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//third_party/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -295,12 +271,8 @@
           "refId": "N"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_slow_target_durations{Target=~\"//tools/.*\"})",
+          "expr": "avg(buildbarn_portal_slow_target_durations{Target=~\"//tools/.*\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -312,10 +284,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Chose a specific target you want to analyze using the dropdown variable",
       "fieldConfig": {
         "defaults": {
@@ -329,6 +297,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -390,14 +359,11 @@
           "sort": "none"
         }
       },
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg( buildbarn_bb_portal_slow_target_durations {Target=~\"$target\"}) by (Target)",
+          "expr": "avg( buildbarn_portal_slow_target_durations {Target=~\"$target\"}) by (Target)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -408,10 +374,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "The targets with the longest execution durations",
       "fieldConfig": {
         "defaults": {
@@ -492,7 +454,9 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "frameIndex": 1,
@@ -504,16 +468,12 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "topk(10, buildbarn_bb_portal_slow_target_durations)",
+          "expr": "topk(10, buildbarn_portal_slow_target_durations)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -592,9 +552,9 @@
       "id": 6,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
           },
           "gridPos": {
             "h": 9,
@@ -621,23 +581,18 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 39,
-  "tags": ["RBE", "BB-Portal"],
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [
+    "RBE",
+    "BB-Portal"
+  ],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": ["//:go"],
-          "value": ["//:go"]
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "mimir"
-        },
+        "current": {},
         "definition": "label_values(Target)",
         "description": "bazel target",
-        "hide": 0,
         "includeAll": false,
         "label": "target",
         "multi": true,
@@ -650,8 +605,6 @@
         },
         "refresh": 1,
         "regex": "^(?!.*Only one).*",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       }
     ]
@@ -664,6 +617,6 @@
   "timezone": "browser",
   "title": "BB Portal - Targets",
   "uid": "cejb2nrz4qry8d",
-  "version": 44,
+  "version": 1,
   "weekStart": ""
 }

--- a/pkg/prometheus_metrics/dashboards/tests.json
+++ b/pkg/prometheus_metrics/dashboards/tests.json
@@ -1,4 +1,38 @@
 {
+  "__inputs": [],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -19,10 +53,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 673529,
+  "id": null,
   "links": [],
   "panels": [
     {
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -30,14 +65,11 @@
         "y": 0
       },
       "id": 9,
+      "panels": [],
       "title": "Breakdowns",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Cached test results are ignored, and we count the number of unique targets executed within the time range",
       "fieldConfig": {
         "defaults": {
@@ -75,7 +107,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -83,15 +117,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count((group( buildbarn_bb_portal_uncached_test_durations ) by (Target) ))",
+          "expr": "count((group( buildbarn_portal_uncached_test_durations ) by (Target) ))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -102,10 +132,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Shows a count of tests by outcome status",
       "fieldConfig": {
         "defaults": {
@@ -136,11 +162,15 @@
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": false,
-          "values": ["percent"]
+          "values": [
+            "percent"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -149,27 +179,19 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Status=\"PASSED\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Status=\"PASSED\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Status=\"FAILED\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Status=\"FAILED\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -177,12 +199,8 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Status=\"FLAKY\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Status=\"FLAKY\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -190,12 +208,8 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Status=\"TIMEOUT\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Status=\"TIMEOUT\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -203,12 +217,8 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Status=\"NO_STATUS\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Status=\"NO_STATUS\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -220,10 +230,6 @@
       "type": "piechart"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Breakdown of tests by where they ran/execution strategy",
       "fieldConfig": {
         "defaults": {
@@ -254,11 +260,15 @@
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": false,
-          "values": ["percent"]
+          "values": [
+            "percent"
+          ]
         },
         "pieType": "donut",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -267,27 +277,19 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Strategy=\"indeterminate\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Strategy=\"indeterminate\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Strategy=\"linux-sandbox\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Strategy=\"linux-sandbox\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -295,12 +297,8 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Strategy=\"local\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Strategy=\"local\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -308,12 +306,8 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "count(buildbarn_bb_portal_uncached_test_durations{Strategy=\"remote\"})",
+          "expr": "count(buildbarn_portal_uncached_test_durations{Strategy=\"remote\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -325,10 +319,6 @@
       "type": "piechart"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "Across all tests",
       "fieldConfig": {
         "defaults": {
@@ -366,7 +356,9 @@
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -374,15 +366,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "avg(buildbarn_bb_portal_uncached_test_durations) * .000001",
+          "expr": "avg(buildbarn_portal_uncached_test_durations) * .000001",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -406,10 +394,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "This is a measure of the test duration for test executions that did not return a cached response during the time window",
       "fieldConfig": {
         "defaults": {
@@ -489,7 +473,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -500,15 +486,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "topk(10, buildbarn_bb_portal_uncached_test_durations)",
+          "expr": "topk(10, buildbarn_portal_uncached_test_durations)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -576,10 +558,6 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -659,7 +637,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -670,15 +650,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "topk(10, buildbarn_bb_portal_uncached_test_durations{Strategy=\"remote\"})",
+          "expr": "topk(10, buildbarn_portal_uncached_test_durations{Strategy=\"remote\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -759,10 +735,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -841,7 +813,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -852,15 +826,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "buildbarn_bb_portal_uncached_test_durations{Status=\"TIMEOUT\"}",
+          "expr": "buildbarn_portal_uncached_test_durations{Status=\"TIMEOUT\"}",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -916,10 +886,6 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "mimir"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -998,7 +964,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -1009,15 +977,11 @@
           }
         ]
       },
-      "pluginVersion": "11.1.4",
+      "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "editorMode": "code",
-          "expr": "buildbarn_bb_portal_uncached_test_durations{Status=\"FLAKY\"}",
+          "expr": "buildbarn_portal_uncached_test_durations{Status=\"FLAKY\"}",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1083,11 +1047,11 @@
       "id": 13,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "mimir"
-          },
           "description": "Information about this dashboard",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 12,
@@ -1113,8 +1077,12 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 39,
-  "tags": ["RBE", "BB-Portal"],
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [
+    "RBE",
+    "BB-Portal"
+  ],
   "templating": {
     "list": []
   },
@@ -1126,6 +1094,6 @@
   "timezone": "browser",
   "title": "BB Portal - Tests",
   "uid": "fejbefgy77aioe",
-  "version": 37,
+  "version": 1,
   "weekStart": ""
 }

--- a/pkg/prometheus_metrics/metrics.go
+++ b/pkg/prometheus_metrics/metrics.go
@@ -35,7 +35,7 @@ var (
 func RegisterMetrics() {
 	CacheHitRate = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "buildbarn",
-		Subsystem: "bb-portal",
+		Subsystem: "portal",
 		Name:      "remote_cache_hit_rate",
 		Help:      "Cache hit rate for action cache or content addressable storage across all invocations",
 		Buckets:   []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
@@ -43,21 +43,21 @@ func RegisterMetrics() {
 
 	Invocations = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "buildbarn",
-		Subsystem: "bb-portal",
+		Subsystem: "portal",
 		Name:      "invocation_counts",
 		Help:      "Number of Invocations Per Host, User and Step Label",
 	}, []string{"Host", "User", "StepLabel"})
 
 	TargetDurations = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "buildbarn",
-		Subsystem: "bb-portal",
+		Subsystem: "portal",
 		Name:      "slow_target_durations",
 		Help:      "Duration of targets that took greater than 2 seconds to complete",
 	}, []string{"Target"})
 
 	TestDurations = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "buildbarn",
-		Subsystem: "bb-portal",
+		Subsystem: "portal",
 		Name:      "uncached_test_durations",
 		Help:      "Durations of tests by target and status",
 	}, []string{"Target", "Status", "Strategy"})


### PR DESCRIPTION
This PR removes the hard coded pprof server and prometheus metrics server. Both of these can be accessed in the diagnostics http server by configuring `global.diagnosticsHttpServer.enablePprof` and `global.diagnosticsHttpServer.enablePrometheus` (even the portal-specific metrics).

It also changes the Prometheus subsystem from `bb-portal` to just `portal`. I had problems getting these metrics into Prometheus, but when I changed the subsystem to not include `-` it worked. Also `buildbarn_bb_portal_...` is a bit unnecessary. The PR also changes the dashboard templates to be more general and work with more setups.