### PR TITLE
Increase max console output size

### DIFF
--- a/frontend/src/components/BrowserActionGrid/fetch.ts
+++ b/frontend/src/components/BrowserActionGrid/fetch.ts
@@ -168,7 +168,7 @@ export const getActionConsoleOutput = async (
     return undefined;
   }
 
-  const MAX_CONSOLE_OUTPUT_SIZE = 10000;
+  const MAX_CONSOLE_OUTPUT_SIZE = 100000;
   if (Number.parseInt(digest.sizeBytes) > MAX_CONSOLE_OUTPUT_SIZE) {
     return {
       name,


### PR DESCRIPTION
Increase max console output size for the action result. The previous was a bit too restrictive.