### PR TITLE
Link to Historical Execute Response page

### DIFF
--- a/frontend/src/components/OperationStateDisplay/index.tsx
+++ b/frontend/src/components/OperationStateDisplay/index.tsx
@@ -8,6 +8,10 @@ import Link from "next/link";
 import OperationStatusTag from "../OperationStatusTag";
 import { operationsStateToActionPageUrl } from "../OperationsGrid/utils";
 import PropertyTagList from "../PropertyTagList";
+import {
+  historicalExecuteResponseDigestFromUrl,
+  historicalExecuteResponseUrlFromOperation,
+} from "./utils";
 
 interface Props {
   operation: OperationState;
@@ -17,6 +21,11 @@ const OperationStateDisplay: React.FC<Props> = ({ operation }) => {
   const invocationMetadata = operation.invocationName?.ids?.map((value) => {
     return JSON.stringify(protobufToObjectWithTypeField(value, false));
   });
+
+  const historical_execute_response_url =
+    historicalExecuteResponseUrlFromOperation(operation);
+  const historical_execute_response_digest =
+    historicalExecuteResponseDigestFromUrl(historical_execute_response_url);
 
   return (
     <Space direction="vertical" size="middle" style={{ display: "flex" }}>
@@ -66,6 +75,14 @@ const OperationStateDisplay: React.FC<Props> = ({ operation }) => {
             >{`${operation.actionDigest.hash}-${operation.actionDigest.sizeBytes}`}</Link>
           )}
         </Descriptions.Item>
+        {historical_execute_response_url &&
+          historical_execute_response_digest && (
+            <Descriptions.Item label="Historical execute response digest">
+              <Link href={historical_execute_response_url}>
+                {historical_execute_response_digest}
+              </Link>
+            </Descriptions.Item>
+          )}
         <Descriptions.Item label="Timeout">
           {operation.timeout &&
             `${dayjs(operation.timeout).diff(undefined, "seconds")}s`}

--- a/frontend/src/components/OperationStateDisplay/utils.ts
+++ b/frontend/src/components/OperationStateDisplay/utils.ts
@@ -1,0 +1,20 @@
+import type { OperationState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
+
+export const historicalExecuteResponseUrlFromOperation = (
+  operation: OperationState,
+): string | undefined => {
+  if (
+    operation.completed?.message.startsWith("Action details (uncached result):")
+  ) {
+    return operation.completed.message.substring(34);
+  }
+  return undefined;
+};
+
+export const historicalExecuteResponseDigestFromUrl = (
+  url: string | undefined,
+): string | undefined => {
+  if (!url) return undefined;
+  const match = url.match(/([a-f0-9]{64})-[0-9]+/);
+  return match ? match[0] : undefined;
+};

--- a/frontend/src/components/OperationsGrid/Columns.tsx
+++ b/frontend/src/components/OperationsGrid/Columns.tsx
@@ -3,6 +3,10 @@ import type { OperationState } from "@/lib/grpc-client/buildbarn/buildqueuestate
 import { type TableColumnsType, Typography } from "antd";
 import type { ColumnType } from "antd/lib/table";
 import Link from "next/link";
+import {
+  historicalExecuteResponseDigestFromUrl,
+  historicalExecuteResponseUrlFromOperation,
+} from "../OperationStateDisplay/utils";
 import OperationStatusTag from "../OperationStatusTag";
 import { operationsStateToActionPageUrl } from "./utils";
 
@@ -23,13 +27,28 @@ const timeoutColumn: ColumnType<OperationState> = {
 };
 
 const actionDigestColumn: ColumnType<OperationState> = {
-  title: "Action digest",
+  title: "Action digest / Historical execute response digest",
   key: "actionDigest",
-  render: (record: OperationState) => (
-    <Link
-      href={operationsStateToActionPageUrl(record) || ""}
-    >{`${record.actionDigest?.hash}-${record.actionDigest?.sizeBytes}`}</Link>
-  ),
+  render: (record: OperationState) => {
+    const historical_execute_response_url =
+      historicalExecuteResponseUrlFromOperation(record);
+    const historical_execute_response_digest =
+      historicalExecuteResponseDigestFromUrl(historical_execute_response_url);
+
+    if (historical_execute_response_digest && historical_execute_response_url) {
+      return (
+        <Link href={historical_execute_response_url}>
+          {historical_execute_response_digest}
+        </Link>
+      );
+    }
+
+    return (
+      <Link
+        href={operationsStateToActionPageUrl(record) || ""}
+      >{`${record.actionDigest?.hash}-${record.actionDigest?.sizeBytes}`}</Link>
+    );
+  },
 };
 
 const targetIdColumn: ColumnType<OperationState> = {


### PR DESCRIPTION
If we know that the action related to an operation has failed, link to the historical execute response page instead.