### PR TITLE
Raw CLI options

### DIFF
--- a/frontend/src/components/CommandLine/index.tsx
+++ b/frontend/src/components/CommandLine/index.tsx
@@ -24,40 +24,31 @@ const CommandLineDisplay: React.FC<{ commandLineData: BazelCommand | undefined |
         <Space direction="vertical" size="middle" style={{ display: 'flex' }} >
             <PortalCard type="inner" icon={<CodeOutlined />} titleBits={["Explicit Command Line:", cmdLine]}>
                 <Row>
-                    <Space size="large">
-                        <div>
-                            <List
-                                bordered
-                                header={<div><strong>Effective Command Line Options:</strong></div>}
-                                dataSource={commandLineData?.cmdLine?.filter(x => x !== undefined).toSorted() as string[]}
-                                renderItem={(item) => <List.Item>{item}</List.Item>}
-                            />
-                        </div>
-                    </Space>
+                    <List
+                        bordered
+                        size="small"
+                        header={<div><strong>Raw Command Line Options:</strong></div>}
+                        dataSource={commandLineData?.cmdLine?.filter(x => x !== undefined) as string[]}
+                        renderItem={(item) => <List.Item>{item}</List.Item>}
+                    />
                 </Row>
                 <Row>
-                    <Space size="large">
-                        <div>
-                            <List
-                                bordered
-                                header={<div><strong>Explicit Startup Options:</strong></div>}
-                                dataSource={commandLineData?.explicitStartupOptions?.filter(x => x !== undefined) as string[]}
-                                renderItem={(item) => <List.Item>{item}</List.Item>}
-                            />
-                        </div>
-                    </Space>
+                    <List
+                        bordered
+                        size="small"
+                        header={<div><strong>Explicit Startup Options:</strong></div>}
+                        dataSource={commandLineData?.explicitStartupOptions?.filter(x => x !== undefined) as string[]}
+                        renderItem={(item) => <List.Item>{item}</List.Item>}
+                    />
                 </Row>
                 <Row>
-                    <Space size="large">
-                        <div>
-                            <List
-                                bordered
-                                header={<div><strong>Effective Startup Options:</strong></div>}
-                                dataSource={commandLineData?.startupOptions?.filter(x => x !== undefined) as string[]}
-                                renderItem={(item) => <List.Item>{item}</List.Item>}
-                            />
-                        </div>
-                    </Space>
+                    <List
+                        bordered
+                        size="small"
+                        header={<div><strong>Effective Startup Options:</strong></div>}
+                        dataSource={commandLineData?.startupOptions?.filter(x => x !== undefined) as string[]}
+                        renderItem={(item) => <List.Item>{item}</List.Item>}
+                    />
                 </Row>
             </PortalCard>
         </Space>


### PR DESCRIPTION
The order of CLI options matter in some cases, therefore we want to show the exact list of options used, instead of a sorted list. Also made the page more compact to increase the information density.