### PR TITLE
Invocation logs scroll sideways instead of overflowing

### DIFF
--- a/frontend/src/components/BazelInvocation/index.tsx
+++ b/frontend/src/components/BazelInvocation/index.tsx
@@ -41,7 +41,7 @@ import BuildStepResultTag, {
 } from "@/components/BuildStepResultTag";
 import DownloadButton from "@/components/DownloadButton";
 import Link from "@/components/Link";
-import { LogViewerCard } from "../LogViewer";
+import LogViewer from "../LogViewer";
 import RunnerMetrics from "../RunnerMetrics";
 import AcMetrics from "../ActionCacheMetrics";
 import TargetMetricsDisplay from "../TargetMetrics";
@@ -127,9 +127,6 @@ const BazelInvocation: React.FC<{
   targetData?.map((x) => {
     targetTimes.set(x.label ?? "", x.durationInMs ?? 0);
   });
-
-  //logs
-  const logs: string = buildLogs ?? "no build log data found...";
 
   //build the title
   let { exitCode } = state;
@@ -325,7 +322,7 @@ const BazelInvocation: React.FC<{
               </Tooltip>,
             ]}
           >
-            <LogViewerCard log={logs} copyable={true} />
+            <LogViewer log={buildLogs} />
           </PortalCard>
         </Space>
       ),

--- a/frontend/src/components/Content/index.module.css
+++ b/frontend/src/components/Content/index.module.css
@@ -14,6 +14,7 @@
 .container {
   position: relative;
   min-height: 100vh;
+  max-width: 100vw;
   padding-bottom: calc(var(--footer-height) + 12px) !important;
 }
 

--- a/frontend/src/components/LogViewer/index.tsx
+++ b/frontend/src/components/LogViewer/index.tsx
@@ -1,27 +1,19 @@
-import React, { RefAttributes, useState } from "react";
-import { Card, CardProps } from "antd";
+import PortalAlert from "@/components/PortalAlert";
 import { AnsiUp } from "ansi_up";
-import linkifyHtml from "linkify-html";
+import { Card, type CardProps } from "antd";
+import type React from "react";
+import type { RefAttributes } from "react";
 import { JSX } from "react/jsx-runtime";
 import styles from "./index.module.css";
-import PortalAlert from "@/components/PortalAlert";
 import IntrinsicAttributes = JSX.IntrinsicAttributes;
-import { GET_BUILD_LOGS } from "./graphql";
-import { GetBuildLogsQueryVariables } from "@/graphql/__generated__/graphql";
-import { useQuery } from "@apollo/client";
 
 const ansi = new AnsiUp();
-const MAX_LOG_LENGTH = 50000;
-
-const FILE_EXTENSIONS_IGNORE = [".py", ".so"];
 
 interface Props {
-  invocationId?: string | null;
   log?: string | null;
-  copyable?: boolean;
 }
 
-const LogViewer: React.FC<Props> = ({ log, invocationId }) => {
+const LogViewer: React.FC<Props> = ({ log }) => {
   if (!log) {
     return (
       <PortalAlert
@@ -44,14 +36,12 @@ type LogViewerCardProps = Props &
 
 export const LogViewerCard: React.FC<LogViewerCardProps> = ({
   log,
-  invocationId,
   bordered,
-  copyable,
   ...props
 }) => {
   return (
     <Card bordered={false} {...props}>
-      <LogViewer log={log} invocationId={invocationId} copyable={copyable} />
+      <LogViewer log={log} />
     </Card>
   );
 };


### PR DESCRIPTION
If the logs contain lines that are longer than the width of the page, the page is stretched to fit the line. Now the lines of the logs are contained within its component, and it is able to scroll horizontally to show long lines.