### PR TITLE
Make `saveTargets` return correct result

### DIFF
--- a/pkg/processing/save.go
+++ b/pkg/processing/save.go
@@ -359,7 +359,7 @@ func (act SaveActor) saveTargets(ctx context.Context, summary *summary.Summary) 
 	if summary.SkipTargetData {
 		return []*ent.TargetPair{}, nil
 	}
-	return []*ent.TargetPair{}, nil
+	return result, nil
 }
 
 func (act SaveActor) saveTestSummary(ctx context.Context, testSummary summary.TestSummary, label string) (*ent.TestSummary, error) {


### PR DESCRIPTION
A bug makes it so that we never return the saved targets so that they can be added to the invocation.