### PR TITLE
Normalize invocation logs

### DIFF
--- a/pkg/summary/summarizer.go
+++ b/pkg/summary/summarizer.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"google.golang.org/api/iterator"
@@ -178,25 +177,12 @@ func (s Summarizer) ProcessEvent(buildEvent *events.BuildEvent) error {
 
 // handleBuildProgress function to extract std out and std err from build progress event
 func (s Summarizer) handleBuildProgress(progress *bes.Progress) {
-	result := progress.GetStdout()
-	if progress.GetStderr() != progress.GetStdout() {
-		result += progress.GetStderr()
-	}
-	// remove duplicate lines from w/in the same screen of output
-	if result != "" {
-		result = strings.ReplaceAll(result, "\r", "")
-		lines := strings.Split(result, "\n")
-		uniqueLines := make(map[string]struct{})
-		for _, line := range lines {
-			if _, exists := uniqueLines[line]; !exists {
-				uniqueLines[line] = struct{}{}
-				if line != "" && line != "\n" {
-					if utf8.ValidString(line) {
-						s.summary.BuildLogs.WriteString(sanitizeUTF8(line) + "\n")
-					}
-				}
-			}
-		}
+	stdout := progress.GetStdout()
+	stderr := progress.GetStderr()
+
+	s.summary.BuildLogs.WriteString(stderr)
+	if stderr != stdout {
+		s.summary.BuildLogs.WriteString(stdout)
 	}
 }
 


### PR DESCRIPTION
This PR removes all temporary lines from a invocation log by parsing the ANSI escape codes, so that the log looks like it should when the invocation is done.

I found no golang library that does this kind of manipulation, so I wrote my own implementation. It is not a general solution, but it seems to work for the escape codes that Bazel uses in its output.

Before:
<img width="1291" height="809" alt="image" src="https://github.com/user-attachments/assets/5513318b-c8c3-4265-8031-1d955b8ce142" />

After:
<img width="1291" height="809" alt="image" src="https://github.com/user-attachments/assets/e0c5a85d-d02c-4a1e-98d1-7f2f7dbcab8a" />

Tested with Bazel 7.6.1, 8.0.1, 8.4.1.