### PR TITLE
Add `Open in Perfetto` button

### DIFF
--- a/frontend/src/components/BazelInvocation/index.tsx
+++ b/frontend/src/components/BazelInvocation/index.tsx
@@ -33,7 +33,6 @@ import themeStyles from "@/theme/theme.module.css";
 import BuildStepResultTag, {
   BuildStepResultEnum,
 } from "@/components/BuildStepResultTag";
-import DownloadButton from "@/components/DownloadButton";
 import Link from "@/components/Link";
 import LogViewer from "../LogViewer";
 import TargetMetricsDisplay from "../TargetMetrics";
@@ -45,9 +44,8 @@ import CommandLineDisplay from "../CommandLine";
 import SourceControlDisplay from "../SourceControlDisplay";
 import InvocationOverviewDisplay from "../InvocationOverviewDisplay";
 import BuildProblems from "../Problems";
-import { generateFileUrl } from "@/utils/urlGenerator";
-import { DigestFunction_Value } from "@/lib/grpc-client/build/bazel/remote/execution/v2/remote_execution";
 import ActionStatisticsDisplay from "../ActionStatisticsDisplay";
+import ProfileDropdown from "../ProfileDropdown";
 import ansiRegex from 'ansi-regex';
 
 const ansiEscapeRegex = ansiRegex();
@@ -173,22 +171,12 @@ const BazelInvocation: React.FC<{
   ];
 
   if (profile) {
-    const url = generateFileUrl(
-      instanceName ?? undefined,
-      DigestFunction_Value.SHA256,
-      {
-        hash: profile.digest,
-        sizeBytes: profile.sizeInBytes.toString()
-      },
-      profile.name
-    )
     extraBits.push(
-      <DownloadButton
-        url={url}
-        fileName="profile"
-        buttonLabel="Profile"
-        enabled={true}
-      />
+      <ProfileDropdown
+        instanceName={instanceName ?? undefined}
+        profile={profile}
+        invocationID={invocationID}
+      />,
     );
   }
 

--- a/frontend/src/components/ProfileDropdown/index.tsx
+++ b/frontend/src/components/ProfileDropdown/index.tsx
@@ -1,0 +1,126 @@
+import type { BazelInvocationInfoFragment } from "@/graphql/__generated__/graphql";
+import { DigestFunction_Value } from "@/lib/grpc-client/build/bazel/remote/execution/v2/remote_execution";
+import { generateFileUrl } from "@/utils/urlGenerator";
+import {
+  DownOutlined,
+  DownloadOutlined,
+  ProjectOutlined,
+} from "@ant-design/icons";
+import { Button, Dropdown, type MenuProps, Space } from "antd";
+
+type Profile = NonNullable<BazelInvocationInfoFragment["profile"]>;
+
+const PERFETTO_URL = "https://ui.perfetto.dev";
+
+const getProfileUrl = (
+  instanceName: string | undefined,
+  profile: Profile,
+): string => {
+  return generateFileUrl(
+    instanceName,
+    DigestFunction_Value.SHA256,
+    {
+      hash: profile.digest,
+      sizeBytes: profile.sizeInBytes.toString(),
+    },
+    profile.name,
+  );
+};
+
+const fetchProfileFile = async (
+  instanceName: string | undefined,
+  profile: Profile,
+): Promise<ArrayBuffer> => {
+  const res = await fetch(getProfileUrl(instanceName, profile));
+  if (!res.ok) {
+    return Promise.reject(`Failed to download profile file: ${res.statusText}`);
+  }
+  return res.arrayBuffer();
+};
+
+const waitForPerfettoToLoad = async (handle: Window) => {
+  const timer = setInterval(
+    () => handle.postMessage("PING", PERFETTO_URL),
+    100,
+  );
+
+  // Wait for the Perfetto UI to respond with 'PONG'
+  await new Promise<void>((resolve) => {
+    const listener = (evt: MessageEvent) => {
+      if (evt.data !== "PONG") return;
+      window.removeEventListener("message", listener);
+      resolve();
+    };
+    window.addEventListener("message", listener);
+  });
+
+  window.clearInterval(timer);
+};
+
+function openPerfetto(
+  instanceName: string | undefined,
+  profile: Profile,
+  invocationID: string,
+) {
+  const handle = window.open(PERFETTO_URL);
+  if (!handle) {
+    console.error("Failed to open new window for Perfetto UI");
+    return;
+  }
+
+  Promise.all([
+    fetchProfileFile(instanceName, profile),
+    waitForPerfettoToLoad(handle),
+  ])
+    .then((values) => {
+      handle.postMessage(
+        {
+          perfetto: {
+            buffer: values[0],
+            title: invocationID,
+            fileName: profile.name,
+          },
+        },
+        PERFETTO_URL,
+      );
+    })
+    .catch((error) => {
+      console.error("Error opening Perfetto:", error);
+      // Close the window that we opened earlier
+      handle.close();
+    });
+}
+
+const ProfileDropdown: React.FC<{
+  instanceName: string | undefined;
+  profile: Profile;
+  invocationID: string;
+}> = ({ instanceName, profile, invocationID }) => {
+  const items: MenuProps["items"] = [
+    {
+      label: "Download Profile",
+      key: "download_profile",
+      icon: <DownloadOutlined />,
+      onClick: () => window.open(getProfileUrl(instanceName, profile), "_self"),
+    },
+    {
+      label: "Open in Perfetto",
+      key: "open_in_perfetto",
+      icon: <ProjectOutlined rotate={270} />,
+      onClick: () => openPerfetto(instanceName, profile, invocationID),
+    },
+  ];
+
+  return (
+    <Dropdown menu={{ items }}>
+      <Button>
+        <Space>
+          Profile
+          <DownOutlined />
+        </Space>
+      </Button>
+    </Dropdown>
+  );
+};
+
+export default ProfileDropdown;


### PR DESCRIPTION
Changes the `Download profile` to a dropdown and adds the option `Open in Perfetto`. This new option opens <https://ui.perfetto.dev> in a new tab, and uploads the profile to the new tab witch automatically opens it. It is done in the way that is suggested in the [Perfetto documentation](https://perfetto.dev/docs/visualization/deep-linking-to-perfetto-ui). Since Perfetto is running client side, no data leaves the user's machine.

This partly solves the issue discussed in #77. The problem that the profile file is ephemeral has not been fixed.

<img width="724" height="615" alt="image" src="https://github.com/user-attachments/assets/b4fa6438-5b25-4fc8-abd8-e4b63f521f67" />
<img width="1135" height="725" alt="image" src="https://github.com/user-attachments/assets/b17a13a5-bde8-4977-a475-68006f48c24b" />
