### PR TITLE
Add download button to invocation logs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^5.66.0",
         "@tanstack/react-query-devtools": "^5.66.0",
         "ansi_up": "^6.0.2",
+        "ansi-regex": "^6.1.0",
         "antd": "^5.21.3",
         "dayjs": "^1.11.11",
         "framer-motion": "^11.1.9",
@@ -3078,17 +3079,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
       "dev": true,
@@ -4687,11 +4677,15 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -9853,6 +9847,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -11324,17 +11328,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "9.2.2",
       "dev": true,
@@ -11444,6 +11437,26 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -12617,17 +12630,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.66.0",
     "@tanstack/react-query-devtools": "^5.66.0",
     "ansi_up": "^6.0.2",
+    "ansi-regex": "^6.1.0",
     "antd": "^5.21.3",
     "dayjs": "^1.11.11",
     "framer-motion": "^11.1.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.66.0
         version: 5.66.0(@tanstack/react-query@5.66.0(react@18.3.1))(react@18.3.1)
+      ansi-regex:
+        specifier: ^6.1.0
+        version: 6.1.0
       ansi_up:
         specifier: ^6.0.2
         version: 6.0.2
@@ -1510,8 +1513,8 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.0.1:
-    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
@@ -5798,7 +5801,7 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.0.1: {}
+  ansi-regex@6.1.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -8473,7 +8476,7 @@ snapshots:
 
   strip-ansi@7.1.0:
     dependencies:
-      ansi-regex: 6.0.1
+      ansi-regex: 6.1.0
 
   strip-bom@3.0.0: {}
 

--- a/frontend/src/components/BazelInvocation/index.tsx
+++ b/frontend/src/components/BazelInvocation/index.tsx
@@ -13,7 +13,7 @@ import {
   SystemNetworkStats,
 } from "@/graphql/__generated__/graphql";
 import styles from "../AppBar/index.module.css";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import PortalDuration from "@/components/PortalDuration";
 import PortalCard from "@/components/PortalCard";
 import { Space, Tabs, Tooltip, Typography } from "antd";
@@ -48,6 +48,9 @@ import BuildProblems from "../Problems";
 import { generateFileUrl } from "@/utils/urlGenerator";
 import { DigestFunction_Value } from "@/lib/grpc-client/build/bazel/remote/execution/v2/remote_execution";
 import ActionStatisticsDisplay from "../ActionStatisticsDisplay";
+import ansiRegex from 'ansi-regex';
+
+const ansiEscapeRegex = ansiRegex();
 
 const BazelInvocation: React.FC<{
   invocationOverview: BazelInvocationInfoFragment;
@@ -76,6 +79,11 @@ const BazelInvocation: React.FC<{
 
     //relatedFiles,
   } = invocationOverview;
+
+  const logDownloadUrl = useMemo(
+    () => buildLogs ? `data:text/plain;charset=utf-8,${encodeURIComponent(buildLogs.replace(ansiEscapeRegex, ""))}` : undefined,
+    [buildLogs]
+  );
 
   //data for runner metrics
   var runnerMetrics: RunnerCount[] = [];
@@ -336,6 +344,14 @@ const BazelInvocation: React.FC<{
               <Tooltip title="Bazel emits logs in ANSI format a screen at a time.  They are presented here concatenated for your convenience.">
                 <ExclamationCircleOutlined />
               </Tooltip>,
+              logDownloadUrl && (
+                <DownloadButton
+                  enabled={true}
+                  buttonLabel="Download Log"
+                  fileName="log.txt"
+                  url={logDownloadUrl}
+                />
+              ),
             ]}
           >
             <LogViewer log={buildLogs} />

--- a/frontend/src/components/Link/index.tsx
+++ b/frontend/src/components/Link/index.tsx
@@ -12,7 +12,7 @@ export interface RequiredLinkProps {
 
 export type LinkProps = RequiredLinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
-const EXTERNAL_LINK_PREFIXES = ['https://', 'http://', 'mailto:'];
+const EXTERNAL_LINK_PREFIXES = ['https://', 'http://', 'mailto:', 'data:'];
 
 const Link: React.FC<LinkProps> = ({ href, children, tooltipTitle, hideFlair, ...props }) => {
   const external = EXTERNAL_LINK_PREFIXES.some(prefix => href.startsWith(prefix));


### PR DESCRIPTION
Adds a "Download" button for invocation logs. It downloads the log by creating a data link that the user can click on. Since the log has lots of ANSI escape codes in it, we need to strip before download.