### PR TITLE
Rework digest and UUID links

### DIFF
--- a/frontend/src/components/CodeLink/index.tsx
+++ b/frontend/src/components/CodeLink/index.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+interface Props {
+  url: string;
+  text: string;
+  abbreviate?: boolean;
+}
+
+const CodeLink: React.FC<Props> = ({ url, text, abbreviate }) => {
+  return (
+    <Link href={url}>
+      <code>
+        {abbreviate === true && text.length > 11
+          ? `${text.slice(0, 8)}...`
+          : text}
+      </code>
+    </Link>
+  );
+};
+
+export default CodeLink;

--- a/frontend/src/components/OperationStateDisplay/index.tsx
+++ b/frontend/src/components/OperationStateDisplay/index.tsx
@@ -1,3 +1,4 @@
+import CodeLink from "@/components/CodeLink";
 import type { OperationState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
 import themeStyles from "@/theme/theme.module.css";
 import { protobufToObjectWithTypeField } from "@/utils/protobufToObject";
@@ -73,17 +74,19 @@ const OperationStateDisplay: React.FC<Props> = ({ operation }) => {
         </Descriptions.Item>
         <Descriptions.Item label="Action digest">
           {operation.actionDigest && (
-            <Link
-              href={operationsStateToActionPageUrl(operation) || ""}
-            >{`${operation.actionDigest.hash}-${operation.actionDigest.sizeBytes}`}</Link>
+            <CodeLink
+              text={`${operation.actionDigest.hash}-${operation.actionDigest.sizeBytes}`}
+              url={operationsStateToActionPageUrl(operation) || ""}
+            />
           )}
         </Descriptions.Item>
         {historical_execute_response_url &&
           historical_execute_response_digest && (
             <Descriptions.Item label="Historical execute response digest">
-              <Link href={historical_execute_response_url}>
-                {historical_execute_response_digest}
-              </Link>
+              <CodeLink
+                text={historical_execute_response_digest}
+                url={historical_execute_response_url}
+              />
             </Descriptions.Item>
           )}
         <Descriptions.Item label="Timeout">

--- a/frontend/src/components/OperationsGrid/Columns.tsx
+++ b/frontend/src/components/OperationsGrid/Columns.tsx
@@ -1,8 +1,8 @@
+import CodeLink from "@/components/CodeLink";
 import type { OperationState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
 import { readableDurationFromDates } from "@/utils/time";
 import { type TableColumnsType, Typography } from "antd";
 import type { ColumnType } from "antd/lib/table";
-import Link from "next/link";
 import {
   historicalExecuteResponseDigestFromUrl,
   historicalExecuteResponseUrlFromOperation,
@@ -13,7 +13,9 @@ import { operationsStateToActionPageUrl } from "./utils";
 const operationNameColumn: ColumnType<OperationState> = {
   title: "Operation name",
   dataIndex: "name",
-  render: (value: string) => <Link href={`operations/${value}`}>{value}</Link>,
+  render: (value: string) => (
+    <CodeLink url={`/operations/${value}`} text={value} abbreviate />
+  ),
 };
 
 const timeoutColumn: ColumnType<OperationState> = {
@@ -42,16 +44,20 @@ const actionDigestColumn: ColumnType<OperationState> = {
 
     if (historical_execute_response_digest && historical_execute_response_url) {
       return (
-        <Link href={historical_execute_response_url}>
-          {historical_execute_response_digest}
-        </Link>
+        <CodeLink
+          text={historical_execute_response_digest}
+          url={historical_execute_response_url}
+          abbreviate
+        />
       );
     }
 
     return (
-      <Link
-        href={operationsStateToActionPageUrl(record) || ""}
-      >{`${record.actionDigest?.hash}-${record.actionDigest?.sizeBytes}`}</Link>
+      <CodeLink
+        text={`${record.actionDigest?.hash}`}
+        url={`${operationsStateToActionPageUrl(record)}`}
+        abbreviate
+      />
     );
   },
 };

--- a/frontend/src/components/WorkersGrid/index.tsx
+++ b/frontend/src/components/WorkersGrid/index.tsx
@@ -103,7 +103,20 @@ const WorkersGrid: React.FC<Props> = ({
       <Row>
         <WorkersTable
           listWorkerFilterType={listWorkerFilterType}
-          data={data?.workers}
+          data={data?.workers.map((value: WorkerState) => {
+            // Size class queue is not included in
+            // workerState, so we set it manually.
+            return {
+              ...value,
+              currentOperation: value.currentOperation && {
+                ...value.currentOperation,
+                invocationName: {
+                  ...value.currentOperation?.invocationName,
+                  sizeClassQueueName: sizeClassQueueName,
+                },
+              },
+            };
+          })}
           paginationInfo={data?.paginationInfo}
           isLoading={isLoading}
           pageSize={LIST_WORKERS_PAGE_SIZE}

--- a/frontend/src/components/WorkersTable/Columns.tsx
+++ b/frontend/src/components/WorkersTable/Columns.tsx
@@ -1,3 +1,5 @@
+import CodeLink from "@/components/CodeLink";
+import { operationsStateToActionPageUrl } from "@/components/OperationsGrid/utils";
 import type { WorkerState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
 import { readableDurationFromDates } from "@/utils/time";
 import { type TableColumnsType, Typography } from "antd";
@@ -58,7 +60,15 @@ const operationNameColumn: ColumnType<WorkerState> = {
   title: "Operation name",
   onCell: (value, _) => ({ colSpan: value.currentOperation ? 1 : 0 }),
   render: (_, record) => (
-    <Typography.Text>{record.currentOperation?.name}</Typography.Text>
+    <CodeLink
+      text={`${record.currentOperation?.name}`}
+      url={
+        (record.currentOperation?.name &&
+          `/operations/${record.currentOperation?.name}`) ||
+        ""
+      }
+      abbreviate
+    />
   ),
 };
 
@@ -67,9 +77,15 @@ const actionDigestColumn: ColumnType<WorkerState> = {
   title: "Action digest",
   onCell: (value, _) => ({ colSpan: value.currentOperation ? 1 : 0 }),
   render: (_, record) => (
-    <Typography.Text>
-      {record.currentOperation?.actionDigest?.hash}
-    </Typography.Text>
+    <CodeLink
+      text={`${record.currentOperation?.actionDigest?.hash}`}
+      url={
+        (record.currentOperation &&
+          operationsStateToActionPageUrl(record.currentOperation)) ||
+        ""
+      }
+      abbreviate
+    />
   ),
 };
 


### PR DESCRIPTION
Reworks digests and UUIDs that link to another page. These links are now formatted with a monospace font, and truncated, to free up more space in the interface.

Also, a link has been added from the workers table to each workers current operation.

<img width="376" height="465" alt="image" src="https://github.com/user-attachments/assets/d9aef784-448f-49b4-bd17-6fded5e57101" />
