### PR TITLE
Use new duration formatting for workers and durations

### DIFF
--- a/frontend/src/components/OperationStateDisplay/index.tsx
+++ b/frontend/src/components/OperationStateDisplay/index.tsx
@@ -1,7 +1,10 @@
-import dayjs from "@/lib/dayjs";
 import type { OperationState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
 import themeStyles from "@/theme/theme.module.css";
 import { protobufToObjectWithTypeField } from "@/utils/protobufToObject";
+import {
+  readableDurationFromDates,
+  readableDurationFromSeconds,
+} from "@/utils/time";
 import { ExclamationCircleFilled } from "@ant-design/icons";
 import { Descriptions, Space, Tag } from "antd";
 import Link from "next/link";
@@ -85,7 +88,10 @@ const OperationStateDisplay: React.FC<Props> = ({ operation }) => {
           )}
         <Descriptions.Item label="Timeout">
           {operation.timeout &&
-            `${dayjs(operation.timeout).diff(undefined, "seconds")}s`}
+            readableDurationFromDates(new Date(), operation.timeout, {
+              precision: 1,
+              smallestUnit: "s",
+            })}
         </Descriptions.Item>
         <Descriptions.Item label="Target ID">
           {operation.targetId}
@@ -95,11 +101,17 @@ const OperationStateDisplay: React.FC<Props> = ({ operation }) => {
         </Descriptions.Item>
         <Descriptions.Item label="Expected duration">
           {operation.expectedDuration &&
-            `${dayjs.duration(Number.parseInt(operation.expectedDuration.seconds), "seconds").asMinutes()}m`}
+            readableDurationFromSeconds(
+              Number.parseInt(operation.expectedDuration.seconds),
+              { precision: 1, smallestUnit: "s" },
+            )}
         </Descriptions.Item>
         <Descriptions.Item label="Age">
           {operation.queuedTimestamp &&
-            `${dayjs().diff(operation.queuedTimestamp, "seconds")}s`}
+            readableDurationFromDates(operation.queuedTimestamp, new Date(), {
+              precision: 1,
+              smallestUnit: "s",
+            })}
         </Descriptions.Item>
         <Descriptions.Item label="Stage">
           <OperationStatusTag operation={operation} />

--- a/frontend/src/components/OperationsGrid/Columns.tsx
+++ b/frontend/src/components/OperationsGrid/Columns.tsx
@@ -1,5 +1,5 @@
-import dayjs from "@/lib/dayjs";
 import type { OperationState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
+import { readableDurationFromDates } from "@/utils/time";
 import { type TableColumnsType, Typography } from "antd";
 import type { ColumnType } from "antd/lib/table";
 import Link from "next/link";
@@ -21,7 +21,12 @@ const timeoutColumn: ColumnType<OperationState> = {
   dataIndex: "timeout",
   render: (value: Date | undefined) => (
     <Typography.Text>
-      {value ? `${dayjs(value).diff(undefined, "seconds")}s` : "∞"}
+      {value
+        ? readableDurationFromDates(new Date(), value, {
+            precision: 1,
+            smallestUnit: "s",
+          })
+        : "∞"}
     </Typography.Text>
   ),
 };

--- a/frontend/src/components/WorkersTable/Columns.tsx
+++ b/frontend/src/components/WorkersTable/Columns.tsx
@@ -1,4 +1,5 @@
 import type { WorkerState } from "@/lib/grpc-client/buildbarn/buildqueuestate/buildqueuestate";
+import { readableDurationFromDates } from "@/utils/time";
 import { type TableColumnsType, Typography } from "antd";
 import type { ColumnType } from "antd/lib/table";
 import PropertyTagList from "../PropertyTagList";
@@ -19,7 +20,14 @@ const workerTimeoutColumn: ColumnType<WorkerState> = {
   key: "workerTimeout",
   title: "Worker timeout",
   render: (_, record) => (
-    <Typography.Text>{record.timeout?.toISOString() || "∞"}</Typography.Text>
+    <Typography.Text>
+      {(record.timeout &&
+        readableDurationFromDates(new Date(), record.timeout, {
+          precision: 1,
+          smallestUnit: "s",
+        })) ||
+        "∞"}
+    </Typography.Text>
   ),
 };
 
@@ -33,7 +41,13 @@ const operationTimeoutColumn: ColumnType<WorkerState> = {
   render: (_, record) => (
     <Typography.Text>
       {record.currentOperation
-        ? record.currentOperation?.timeout?.toISOString() || "∞"
+        ? (record.currentOperation?.timeout &&
+            readableDurationFromDates(
+              new Date(),
+              record.currentOperation.timeout,
+              { precision: 1, smallestUnit: "s" },
+            )) ||
+          "∞"
         : "Idle"}
     </Typography.Text>
   ),


### PR DESCRIPTION
Use the new duration formatting introduced in #152 to format durations found in the worker and operations page.