### PR TITLE
Invocation timeline

### DIFF
--- a/frontend/src/app/builds/[buildUUID]/[[...slugs]]/page.tsx
+++ b/frontend/src/app/builds/[buildUUID]/[[...slugs]]/page.tsx
@@ -22,6 +22,7 @@ import BuildStepResultTag, {
 import PortalDuration from "@/components/PortalDuration";
 import { isFeatureEnabled, FeatureType } from '@/utils/isFeatureEnabled';
 import PageDisabled from "@/components/PageDisabled";
+import CollapsableInvocationTimeline from "@/components/CollapsableInvocationTimeline";
 
 interface PageParams {
   params: {
@@ -287,6 +288,11 @@ const PageContent: React.FC<PageParams> = ({ params }) => {
           extraBits={extraBits}
         >
           <Space direction="vertical" style={{ width: "100%" }}>
+            {responseData?.getBuild?.invocations && (
+              <CollapsableInvocationTimeline
+                invocations={responseData.getBuild?.invocations}
+              />
+            )}
             <Table columns={columns} dataSource={result} pagination={false} />
           </Space>
         </PortalCard>

--- a/frontend/src/app/builds/[buildUUID]/[[...slugs]]/types.ts
+++ b/frontend/src/app/builds/[buildUUID]/[[...slugs]]/types.ts
@@ -1,0 +1,5 @@
+import type { FindBuildByUuidQuery } from "@/graphql/__generated__/graphql";
+
+export type FindBuildFromUuidFragment = NonNullable<
+  NonNullable<FindBuildByUuidQuery["getBuild"]>["invocations"]
+>[number];

--- a/frontend/src/components/CollapsableInvocationTimeline/index.tsx
+++ b/frontend/src/components/CollapsableInvocationTimeline/index.tsx
@@ -1,0 +1,24 @@
+import type { FindBuildFromUuidFragment } from "@/app/builds/[buildUUID]/[[...slugs]]/types";
+import InvocationTimeline from "@/components/InvocationTimeline";
+import { Collapse, Typography } from "antd";
+
+interface Props {
+  invocations: FindBuildFromUuidFragment[];
+}
+
+const CollapsableInvocationTimeline: React.FC<Props> = ({ invocations }) => {
+  return (
+    <Collapse
+      bordered={false}
+      items={[
+        {
+          key: 0,
+          label: <Typography.Text strong>Invocation Timeline</Typography.Text>,
+          children: <InvocationTimeline invocations={invocations} />,
+        },
+      ]}
+    />
+  );
+};
+
+export default CollapsableInvocationTimeline;

--- a/frontend/src/components/InvocationTimeline/index.tsx
+++ b/frontend/src/components/InvocationTimeline/index.tsx
@@ -1,0 +1,139 @@
+import type { FindBuildFromUuidFragment } from "@/app/builds/[buildUUID]/[[...slugs]]/types";
+import dayjs from "@/lib/dayjs";
+import {
+  readableDurationFromDates,
+  readableDurationFromMilliseconds,
+} from "@/utils/time";
+import { theme } from "antd";
+import Link from "next/link";
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { InvocationInfo, TickProps } from "./types";
+import { getBarColor } from "./utils";
+
+interface Props {
+  invocations: FindBuildFromUuidFragment[];
+}
+
+const BAR_HEIGHT = 20;
+const CHART_PADDING = 40;
+
+const InvocationTimeline: React.FC<Props> = ({ invocations }) => {
+  const { token } = theme.useToken();
+
+  const invocationsInfo: InvocationInfo[] = useMemo(
+    () =>
+      invocations.map((entry) => {
+        return {
+          invocationId: entry.invocationID,
+          // Timestamp interval in milliseconds since UNIX epoch.
+          timestamps: [
+            dayjs(entry.startedAt).valueOf(),
+            entry.endedAt ? dayjs(entry.endedAt).valueOf() : undefined,
+          ],
+          exitCode: entry.state.exitCode?.name,
+        };
+      }),
+    [invocations],
+  );
+
+  // Place X-axis ticks at all defined timestamps.
+  const ticks: number[] = useMemo(
+    () =>
+      invocationsInfo
+        .flatMap((entry) => entry.timestamps)
+        .filter((t): t is number => typeof t === "number"),
+    [invocationsInfo],
+  );
+  const min = Math.min(...ticks);
+  const max = Math.max(...ticks);
+
+  const renderVerticalAxisTick = ({ x, y, payload }: TickProps) => {
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <Link href={`/bazel-invocations/${payload.value}`}>
+          <text x={0} y={0} dy={8} textAnchor="end" fill={token.colorLink}>
+            {`${payload.value.slice(0, 5)}...`}
+          </text>
+        </Link>
+      </g>
+    );
+  };
+
+  return (
+    <ResponsiveContainer
+      height={invocationsInfo.length * BAR_HEIGHT + CHART_PADDING}
+      width="100%"
+    >
+      <BarChart layout="vertical" data={invocationsInfo}>
+        <XAxis
+          domain={[min, max]}
+          type="number"
+          ticks={ticks}
+          tickFormatter={(value) => {
+            return readableDurationFromDates(
+              dayjs(min).toDate(),
+              dayjs(value).toDate(),
+              { precision: 1, smallestUnit: "s" },
+            );
+          }}
+        />
+        <YAxis
+          dataKey="invocationId"
+          type="category"
+          tick={renderVerticalAxisTick}
+          interval={0}
+        />
+        <CartesianGrid horizontal={false} syncWithTicks strokeDasharray="3 3" />
+        <Tooltip
+          // The label text turns white (against a white background, turning
+          // it practically invisible) in dark mode unless color is set.
+          labelStyle={{ color: "black" }}
+          labelFormatter={(label, payload) => {
+            const startedAt: number | undefined =
+              payload[0]?.payload?.timestamps[0];
+            const endedAt: number | undefined =
+              payload[0]?.payload?.timestamps[1];
+            return (
+              <>
+                <b>{label}</b>
+                {startedAt && (
+                  <p>Started at: {dayjs(startedAt).toISOString()}</p>
+                )}
+                {endedAt && <p>Ended at: {dayjs(endedAt).toISOString()}</p>}
+              </>
+            );
+          }}
+          formatter={(value: number[], name: string) => {
+            // TODO: Handle in-progress invocations
+            return [
+              readableDurationFromMilliseconds(value[1] - value[0]),
+              name,
+            ];
+          }}
+        />
+        <Bar
+          dataKey="timestamps"
+          name="Duration"
+          minPointSize={5}
+          barSize={BAR_HEIGHT}
+        >
+          {invocationsInfo.map((entry) => (
+            <Cell key={entry.invocationId} fill={getBarColor(entry.exitCode)} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default InvocationTimeline;

--- a/frontend/src/components/InvocationTimeline/types.ts
+++ b/frontend/src/components/InvocationTimeline/types.ts
@@ -1,0 +1,12 @@
+import type { SVGProps } from "react";
+import type { CartesianTickItem } from "recharts/types/util/types";
+
+export interface TickProps extends SVGProps<SVGTextElement> {
+  payload: CartesianTickItem;
+}
+
+export interface InvocationInfo {
+  invocationId: string;
+  timestamps: (number | undefined)[];
+  exitCode?: string;
+}

--- a/frontend/src/components/InvocationTimeline/utils.ts
+++ b/frontend/src/components/InvocationTimeline/utils.ts
@@ -1,0 +1,28 @@
+import { BuildStepResultEnum } from "@/components/BuildStepResultTag";
+
+export const getBarColor = (exitCode: string | undefined): string => {
+  // Corresponds to the tag colors in
+  // @/components/BuildStepResultTag
+  switch (exitCode) {
+    case BuildStepResultEnum.SUCCESS:
+      return "green";
+    case BuildStepResultEnum.UNSTABLE:
+      return "orange";
+    case BuildStepResultEnum.PARSING_FAILURE:
+      return "red";
+    case BuildStepResultEnum.BUILD_FAILURE:
+      return "red";
+    case BuildStepResultEnum.TESTS_FAILED:
+      return "red";
+    case BuildStepResultEnum.NOT_BUILT:
+      return "purple";
+    case BuildStepResultEnum.ABORTED:
+      return "cyan";
+    case BuildStepResultEnum.INTERRUPTED:
+      return "cyan";
+    case BuildStepResultEnum.UNKNOWN:
+      return "grey";
+    default:
+      return "grey";
+  }
+};


### PR DESCRIPTION
Adds a collapsible timeline over all invocations in a build. The timeline shows relative start- and end-times, as well as the status of each invocation. If you hover over a row in the timeline, you get the exact start- and end-time as well as the duration for the invocation.

<img width="2386" height="1044" alt="image" src="https://github.com/user-attachments/assets/6a2e4baa-ffec-40e5-996f-4ba4cc107b2b" />

<img width="2386" height="1202" alt="image" src="https://github.com/user-attachments/assets/12331f19-3891-42a6-93e4-cc4aeb866f3d" />

The hover information:
<img width="2162" height="280" alt="image" src="https://github.com/user-attachments/assets/1611b929-224b-4215-8267-0979c05aac93" />
