### PR TITLE
Replace breadcrumb home icon with the Buildbarn icon

### DIFF
--- a/frontend/src/components/Breadcrumbs/index.tsx
+++ b/frontend/src/components/Breadcrumbs/index.tsx
@@ -3,10 +3,10 @@
 import React, { useMemo } from 'react';
 import { Breadcrumb, Typography } from 'antd';
 import { BreadcrumbItemType } from 'antd/lib/breadcrumb/Breadcrumb';
-import { HomeOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import styles from '@/components/Breadcrumbs/index.module.css';
+import BuildbarnIcon from '../BuildbarnIcon';
 
 // Define a common separator reference
 const separator: string = '/';
@@ -74,7 +74,7 @@ const Breadcrumbs: React.FC<Props> = ({ segmentTitles }) => {
       });
 
       // Return the list of breadcrumbs items along with a way home
-      return [{ path: separator, title: <HomeOutlined /> }, ...breadcrumbs];
+      return [{ path: separator, title: <BuildbarnIcon /> }, ...breadcrumbs];
 
       // Only update the breadcrumb item list when the path has changed
     },

--- a/frontend/src/components/BuildbarnIcon/BuildbarnIconSvg.tsx
+++ b/frontend/src/components/BuildbarnIcon/BuildbarnIconSvg.tsx
@@ -1,0 +1,91 @@
+import type React from "react";
+
+const BuildbarnIconSvg: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    viewBox="-0.5 -0.5 421 421"
+    {...props}
+  >
+    <title>{props.name}</title>
+    <defs />
+    <g>
+      <rect
+        x="180"
+        y="120"
+        width="60"
+        height="60"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        pointer-events="all"
+      />
+      <path
+        stroke-linecap="round"
+        d="M 10 250 L 50 90 L 210 11 L 370 90 L 410 250"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        stroke-miterlimit="10"
+        pointer-events="stroke"
+      />
+      <path
+        stroke-linecap="round"
+        d="M 70 410 L 70 210"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        stroke-miterlimit="10"
+        pointer-events="stroke"
+      />
+      <path
+        stroke-linecap="round"
+        d="M 350 410 L 350 210"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        stroke-miterlimit="10"
+        pointer-events="stroke"
+      />
+      <path
+        stroke-linecap="round"
+        d="M 10 410 L 410 410"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        stroke-miterlimit="10"
+        pointer-events="stroke"
+      />
+      <rect
+        x="140"
+        y="270"
+        width="140"
+        height="140"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        pointer-events="all"
+      />
+      <path
+        stroke-linecap="round"
+        d="M 140 410 L 280 270"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        stroke-miterlimit="10"
+        pointer-events="stroke"
+      />
+      <path
+        stroke-linecap="round"
+        d="M 140 270 L 280 410"
+        fill="none"
+        stroke={props.stroke || "rgb(0, 0, 0)"}
+        stroke-width="20"
+        stroke-miterlimit="10"
+        pointer-events="stroke"
+      />
+    </g>
+  </svg>
+);
+
+export default BuildbarnIconSvg;

--- a/frontend/src/components/BuildbarnIcon/index.tsx
+++ b/frontend/src/components/BuildbarnIcon/index.tsx
@@ -1,0 +1,30 @@
+import Icon from "@ant-design/icons";
+import { theme } from "antd";
+import BuildbarnIconSvg from "./BuildbarnIconSvg";
+
+const ICON_SIZE = 20;
+
+const { useToken } = theme;
+
+const BuildbarnIcon: React.FC = () => {
+  const { token } = useToken();
+
+  const renderIconImage = () => {
+    return (
+      <Icon
+        component={() => (
+          <BuildbarnIconSvg
+            width={ICON_SIZE}
+            height={ICON_SIZE}
+            stroke={token.colorText}
+            name="Home"
+          />
+        )}
+      />
+    );
+  };
+
+  return <Icon component={renderIconImage} />;
+};
+
+export default BuildbarnIcon;


### PR DESCRIPTION
The home icon at the root of the breadcrumbs has been changed from a generic house icon to the Buildbarn icon.

<img width="750" height="139" alt="image" src="https://github.com/user-attachments/assets/d7a28f0e-98ef-4f50-8d88-51e0f8ec1d3f" />
