### PR TITLE
Fix broken publishing to ghcr.io

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -111,6 +111,6 @@
    },
    "permissions": {
       "contents": "read",
-      "id-token": "write"
+      "packages": "write"
    }
 }

--- a/tools/github_workflows/github_workflows.jsonnet
+++ b/tools/github_workflows/github_workflows.jsonnet
@@ -125,7 +125,7 @@ local lint_steps = [
       push: { branches: ["main"] },
       workflow_dispatch: null,
     },
-    permissions: { contents: "read", "id-token": "write" },
+    permissions: { contents: "read", "packages": "write" },
     jobs: {
       publish_backend: {
         name: "Publish Backend (Bazel)",


### PR DESCRIPTION
The workflow that publishes Docker images to GitHub Container Registry had incorrect permissions set, preventing it from functioning properly. This commit updates the permissions to allow writing to packages.