### PR TITLE
Set `UserUUID` to the SHA-1 of `ExternalID`

### DIFF
--- a/cmd/bb_portal/BUILD.bazel
+++ b/cmd/bb_portal/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
         "@com_github_buildbarn_bb_storage//pkg/proto/fsac",
         "@com_github_buildbarn_bb_storage//pkg/proto/iscc",
         "@com_github_buildbarn_bb_storage//pkg/util",
-        "@com_github_google_uuid//:uuid",
         "@com_github_gorilla_mux//:mux",
         "@com_github_improbable_eng_grpc_web//go/grpcweb",
         "@com_github_rs_cors//:cors",

--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -18,7 +18,6 @@ import (
 
 	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 
@@ -177,7 +176,7 @@ func newBuildEventStreamService(
 
 	// Handle BEP file uploads over HTTP.
 	if besConfiguration.EnableBepFileUpload {
-		bepUploader, err := bepuploader.NewBepUploader(dbClient, configuration, dependenciesGroup, grpcClientFactory, tracerProvider, uuid.NewRandom)
+		bepUploader, err := bepuploader.NewBepUploader(dbClient, configuration, dependenciesGroup, grpcClientFactory, tracerProvider)
 		if err != nil {
 			return util.StatusWrap(err, "Failed to create BEP file upload handler")
 		}
@@ -185,7 +184,7 @@ func newBuildEventStreamService(
 	}
 
 	// Handle the build event stream gRPC strem.
-	buildEventServer, err := bes.NewBuildEventServer(dbClient, configuration, dependenciesGroup, grpcClientFactory, tracerProvider, uuid.NewRandom)
+	buildEventServer, err := bes.NewBuildEventServer(dbClient, configuration, dependenciesGroup, grpcClientFactory, tracerProvider)
 	if err != nil {
 		return util.StatusWrap(err, "Failed to create BuildEventServer")
 	}

--- a/internal/api/grpc/bes/server.go
+++ b/internal/api/grpc/bes/server.go
@@ -35,7 +35,7 @@ type BuildEventServer struct {
 }
 
 // NewBuildEventServer creates a new BuildEventServer
-func NewBuildEventServer(db database.Client, configuration *bb_portal.ApplicationConfiguration, dependenciesGroup program.Group, grpcClientFactory bb_grpc.ClientFactory, tracerProvider trace.TracerProvider, uuidGenerator util.UUIDGenerator) (*BuildEventServer, error) {
+func NewBuildEventServer(db database.Client, configuration *bb_portal.ApplicationConfiguration, dependenciesGroup program.Group, grpcClientFactory bb_grpc.ClientFactory, tracerProvider trace.TracerProvider) (*BuildEventServer, error) {
 	if configuration.InstanceNameAuthorizer == nil {
 		return nil, status.Error(codes.NotFound, "No InstanceNameAuthorizer configured")
 	}
@@ -71,7 +71,6 @@ func NewBuildEventServer(db database.Client, configuration *bb_portal.Applicatio
 				invocationID,
 				true, /* isRealTime */
 				extractors,
-				uuidGenerator,
 			)
 			if err != nil {
 				return nil, err

--- a/internal/api/http/bepuploader/bepuploader.go
+++ b/internal/api/http/bepuploader/bepuploader.go
@@ -39,11 +39,10 @@ type BepUploader struct {
 	saveDataLevel          *bb_portal.BuildEventStreamService_SaveDataLevel
 	tracerProvider         trace.TracerProvider
 	extractors             *authmetadataextraction.AuthMetadataExtractors
-	uuidGenerator          util.UUIDGenerator
 }
 
 // NewBepUploader creates a new BepUploader
-func NewBepUploader(db database.Client, configuration *bb_portal.ApplicationConfiguration, dependenciesGroup program.Group, grpcClientFactory bb_grpc.ClientFactory, tracerProvider trace.TracerProvider, uuidGenerator util.UUIDGenerator) (*BepUploader, error) {
+func NewBepUploader(db database.Client, configuration *bb_portal.ApplicationConfiguration, dependenciesGroup program.Group, grpcClientFactory bb_grpc.ClientFactory, tracerProvider trace.TracerProvider) (*BepUploader, error) {
 	if configuration.InstanceNameAuthorizer == nil {
 		return nil, status.Error(codes.NotFound, "No InstanceNameAuthorizer configured")
 	}
@@ -73,7 +72,6 @@ func NewBepUploader(db database.Client, configuration *bb_portal.ApplicationConf
 		saveDataLevel:          saveDataLevel,
 		tracerProvider:         tracerProvider,
 		extractors:             extractors,
-		uuidGenerator:          uuidGenerator,
 	}, nil
 }
 
@@ -129,7 +127,6 @@ func (b *BepUploader) RecordEventNdjsonFile(ctx context.Context, file io.Reader)
 		invocationID,
 		false, // isRealTime,
 		b.extractors,
-		b.uuidGenerator,
 	)
 	if err != nil {
 		return "", gprcErrorCodeToHTTPStatus(err), util.StatusWrap(err, "Failed to create BuildEventRecorder")

--- a/internal/database/buildeventrecorder/build_event_recorder.go
+++ b/internal/database/buildeventrecorder/build_event_recorder.go
@@ -82,7 +82,6 @@ func NewBuildEventRecorder(
 	invocationID string,
 	isRealTime bool,
 	extractors *authmetadataextraction.AuthMetadataExtractors,
-	uuidGenerator util.UUIDGenerator,
 ) (BuildEventRecorder, error) {
 	if invocationID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Invocation ID is required")
@@ -93,7 +92,7 @@ func NewBuildEventRecorder(
 
 	tracer := tracerProvider.Tracer("github.com/buildbarn/bb-portal/internal/database/buildeventrecorder")
 
-	userDb, err := FindOrCreateAuthenticatedUser(ctx, db, extractors, uuidGenerator, prometheusmetrics.AuthenticatedUsersCount)
+	userDb, err := FindOrCreateAuthenticatedUser(ctx, db, extractors, prometheusmetrics.AuthenticatedUsersCount)
 	if err != nil {
 		return nil, util.StatusWrap(err, "Failed to find or create authenticated user")
 	}
@@ -122,7 +121,6 @@ func FindOrCreateAuthenticatedUser(
 	ctx context.Context,
 	db database.Client,
 	extractors *authmetadataextraction.AuthMetadataExtractors,
-	uuidGenerator util.UUIDGenerator,
 	authenticatedUsersGauge prometheus.Gauge,
 ) (*int64, error) {
 	userSummary := authmetadataextraction.AuthenticatedUserSummaryFromContext(ctx, extractors)
@@ -152,7 +150,7 @@ func FindOrCreateAuthenticatedUser(
 
 	authenticatedUserDb, err := db.Sqlc().CreateAuthenticatedUser(ctx,
 		sqlc.CreateAuthenticatedUserParams{
-			UserUuid:    util.Must(uuidGenerator()),
+			UserUuid:    uuid.NewSHA1(uuid.NameSpaceURL, []byte(userSummary.ExternalID)),
 			ExternalID:  userSummary.ExternalID,
 			DisplayName: displayName,
 			UserInfo:    userInfo,

--- a/internal/mock/BUILD.bazel
+++ b/internal/mock/BUILD.bazel
@@ -27,25 +27,12 @@ gomock(
     package = "mock",
 )
 
-gomock(
-    name = "util",
-    out = "util.go",
-    interfaces = [
-        "UUIDGenerator",
-    ],
-    library = "@com_github_buildbarn_bb_storage//pkg/util",
-    mockgen_model_library = "@org_uber_go_mock//mockgen/model",
-    mockgen_tool = "@org_uber_go_mock//mockgen",
-    package = "mock",
-)
-
 go_library(
     name = "mock",
     srcs = [
         "buildqueuestate.go",
         "clock.go",
         "deps.go",
-        "util.go",
     ],
     importpath = "github.com/buildbarn/bb-portal/internal/mock",
     visibility = ["//:__subpackages__"],
@@ -53,8 +40,6 @@ go_library(
     deps = [
         "@com_github_buildbarn_bb_remote_execution//pkg/proto/buildqueuestate",
         "@com_github_buildbarn_bb_storage//pkg/clock",
-        "@com_github_buildbarn_bb_storage//pkg/util",
-        "@com_github_google_uuid//:uuid",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_protobuf//types/known/emptypb",
         "@org_uber_go_mock//gomock",

--- a/pkg/prometheus_metrics/metrics_test.go
+++ b/pkg/prometheus_metrics/metrics_test.go
@@ -40,7 +40,6 @@ func TestMetrics(t *testing.T) {
 			ctx,
 			db,
 			nil,
-			uuid.NewRandom,
 			newAuthenticatedUsersGauge,
 		)
 		require.NoError(t, err)
@@ -56,7 +55,6 @@ func TestMetrics(t *testing.T) {
 			authMetadataCtx,
 			db,
 			authmetadataextraction.ExampleAuthMetadataExtractors(),
-			uuid.NewRandom,
 			newAuthenticatedUsersGauge,
 		)
 		require.NoError(t, err)
@@ -93,7 +91,6 @@ func TestMetrics(t *testing.T) {
 			authMetadataCtx,
 			db,
 			authmetadataextraction.ExampleAuthMetadataExtractors(),
-			uuid.NewRandom,
 			authenticatedUsersGauge,
 		)
 		require.NoError(t, err)
@@ -123,7 +120,6 @@ func TestMetrics(t *testing.T) {
 			authMetadataCtx,
 			db,
 			authmetadataextraction.ExampleAuthMetadataExtractors(),
-			uuid.NewRandom,
 			authenticatedUsersGauge,
 		)
 		require.NoError(t, err)

--- a/test/integrationtest/BUILD.bazel
+++ b/test/integrationtest/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
         "//internal/database/dbauthservice",
         "//internal/database/embedded",
         "//internal/graphql",
-        "//internal/mock",
+        "//pkg/authmetadataextraction",
         "//pkg/proto/configuration/bb_portal",
         "//pkg/testkit",
         "//test/testutils",
@@ -33,6 +33,5 @@ go_test(
         "@io_opentelemetry_go_otel_trace//:trace",
         "@io_opentelemetry_go_otel_trace//noop",
         "@org_golang_google_protobuf//types/known/emptypb",
-        "@org_uber_go_mock//gomock",
     ],
 )

--- a/test/integrationtest/integration_test.go
+++ b/test/integrationtest/integration_test.go
@@ -8,17 +8,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/uuid"
-
 	// Needed to avoid cyclic dependencies in ent (https://entgo.io/docs/privacy#privacy-policy-registration)
 	_ "github.com/buildbarn/bb-portal/ent/gen/ent/runtime"
 	databasecommon "github.com/buildbarn/bb-portal/internal/database/common"
+	"github.com/buildbarn/bb-portal/pkg/authmetadataextraction"
 	"github.com/buildbarn/bb-portal/pkg/proto/configuration/bb_portal"
 	"github.com/buildbarn/bb-portal/pkg/testkit"
 	"github.com/buildbarn/bb-portal/test/testutils"
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	jmespath "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath"
 	"github.com/buildbarn/bb-storage/pkg/util"
+	"github.com/google/uuid"
 	gql "github.com/machinebox/graphql"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -73,7 +73,8 @@ var (
 		filename:     "bb_portal_aborted_tests.ndjson",
 		invocationID: "64719226-555e-494d-9918-0fd25d468b1e",
 	}
-	authenticatedUserUUID = "8bdb3187-e36c-487e-95b8-f8ca28a82068"
+	authenticatedUserExternalID = authmetadataextraction.ExampleExternalID()
+	authenticatedUserUUID       = uuid.NewSHA1(uuid.NameSpaceURL, []byte(authenticatedUserExternalID)).String()
 
 	// An authenticated user UUID not present in any BEP file.
 	authenticatedUserUUIDNotFound = "A80031E0-1A11-4543-894C-13C48056074A"
@@ -272,16 +273,10 @@ var (
 			},
 			ctx: auth.NewContextWithAuthenticationMetadata(context.Background(), util.Must(auth.NewAuthenticationMetadataFromRaw(map[string]any{
 				"private": map[string]any{
-					"external_id":  "6b939a5f-95b9-4a7c-ad89-961fb96c5cd1",
-					"display_name": "example_username",
+					"external_id":  authmetadataextraction.ExampleExternalID(),
+					"display_name": authmetadataextraction.ExampleDisplayName(),
 				},
-				"public": map[string]any{
-					"age": 30,
-					"contact_information": map[string]any{
-						"email":        "user@example.com",
-						"phone_number": "800-555-0199",
-					},
-				},
+				"public": authmetadataextraction.ExampleUserInfo(),
 			}))),
 			mockUUID: &authenticatedUserUUID,
 			graphqlTestCases: graphqlTestTable{
@@ -328,17 +323,9 @@ func runTestCase(t *testing.T, queryRegistry *testkit.QueryRegistry, testCase te
 	if ctx == nil {
 		ctx = context.Background()
 	}
-
-	var uuidGenerator util.UUIDGenerator
-	if testCase.mockUUID != nil {
-		uuidGenerator = createMockUUIDGenerator(t, *testCase.mockUUID, len(testCase.bepFileTestCases))
-	} else {
-		uuidGenerator = uuid.NewRandom
-	}
-
 	db := testutils.SetupTestDB(t, dbProvider)
 
-	bepUploader := setupTestBepUploader(t, db, testCase, uuidGenerator)
+	bepUploader := setupTestBepUploader(t, db, testCase)
 
 	for _, bepFileTestCase := range testCase.bepFileTestCases {
 		t.Run(fmt.Sprintf("SavingFileToDb_%s", bepFileTestCase.bepFile.filename), func(t *testing.T) {

--- a/test/integrationtest/testdata/golden/TestGraphqlQueriesWithAuthMetadata/GetAuthenticatedUser/authenticated-user-found.golden.json
+++ b/test/integrationtest/testdata/golden/TestGraphqlQueriesWithAuthMetadata/GetAuthenticatedUser/authenticated-user-found.golden.json
@@ -20,7 +20,8 @@
       "contact_information": {
         "email": "user@example.com",
         "phone_number": "800-555-0199"
-      }
+      },
+      "full_name": "Example Name"
     }
   }
 }

--- a/test/integrationtest/util_test.go
+++ b/test/integrationtest/util_test.go
@@ -14,16 +14,12 @@ import (
 	"github.com/buildbarn/bb-portal/internal/database/dbauthservice"
 	"github.com/buildbarn/bb-portal/internal/database/embedded"
 	"github.com/buildbarn/bb-portal/internal/graphql"
-	"github.com/buildbarn/bb-portal/internal/mock"
 	"github.com/buildbarn/bb-portal/pkg/proto/configuration/bb_portal"
 	"github.com/buildbarn/bb-storage/pkg/proto/configuration/auth"
-	"github.com/buildbarn/bb-storage/pkg/util"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
-	"go.uber.org/mock/gomock"
 )
 
 var dbProvider *embedded.DatabaseProvider
@@ -39,14 +35,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func createMockUUIDGenerator(t *testing.T, uuidString string, times int) util.UUIDGenerator {
-	ctrl := gomock.NewController(t)
-	uuidGeneratorRecorder := mock.NewMockUUIDGenerator(ctrl)
-	uuidGeneratorRecorder.EXPECT().Call().Return(uuid.MustParse(uuidString), nil).Times(times)
-	return uuidGeneratorRecorder.Call
-}
-
-func setupTestBepUploader(t *testing.T, db database.Client, testCase testCase, uuidGenerator util.UUIDGenerator) *bepuploader.BepUploader {
+func setupTestBepUploader(t *testing.T, db database.Client, testCase testCase) *bepuploader.BepUploader {
 	config := &bb_portal.ApplicationConfiguration{
 		InstanceNameAuthorizer: &auth.AuthorizerConfiguration{
 			Policy: &auth.AuthorizerConfiguration_Allow{},
@@ -56,7 +45,7 @@ func setupTestBepUploader(t *testing.T, db database.Client, testCase testCase, u
 			AuthMetadataKeyConfiguration: testCase.extractors,
 		},
 	}
-	bepUploader, err := bepuploader.NewBepUploader(db, config, nil, nil, noop.NewTracerProvider(), uuidGenerator)
+	bepUploader, err := bepuploader.NewBepUploader(db, config, nil, nil, noop.NewTracerProvider())
 	require.NoError(t, err)
 	return bepUploader
 }


### PR DESCRIPTION
Instead of generating a random UUID for a user, we use a deterministic method of creating the UUID by taking a hash of the external ID.