### PR TITLE
frontend: wrap long text in pre elements

### DIFF
--- a/frontend/src/components/InvocationTargets/InvocationTargetsTable/index.tsx
+++ b/frontend/src/components/InvocationTargets/InvocationTargetsTable/index.tsx
@@ -128,7 +128,7 @@ export const InvocationTargetsTable: React.FC<Props> = ({
           expandedRowRender: (record) => (
             <Space direction="vertical" style={{ paddingLeft: "48px" }}>
               <strong>Failure Message:</strong>
-              <pre>{record.failureMessage}</pre>
+              <pre style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{record.failureMessage}</pre>
             </Space>
           ),
         }}

--- a/frontend/src/components/InvocationTargets/InvocationTargetsTable/index.tsx
+++ b/frontend/src/components/InvocationTargets/InvocationTargetsTable/index.tsx
@@ -128,7 +128,11 @@ export const InvocationTargetsTable: React.FC<Props> = ({
           expandedRowRender: (record) => (
             <Space direction="vertical" style={{ paddingLeft: "48px" }}>
               <strong>Failure Message:</strong>
-              <pre style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{record.failureMessage}</pre>
+              <pre
+                style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}
+              >
+                {record.failureMessage}
+              </pre>
             </Space>
           ),
         }}

--- a/frontend/src/components/pages/TargetDetails/index.tsx
+++ b/frontend/src/components/pages/TargetDetails/index.tsx
@@ -193,7 +193,7 @@ const TargetDetails: React.FC<Props> = ({
             expandedRowRender: (record) => (
               <Space direction="vertical" style={{ paddingLeft: "48px" }}>
                 <strong>Failure Message:</strong>
-                <pre>{record.failureMessage}</pre>
+                <pre style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{record.failureMessage}</pre>
               </Space>
             ),
           }}

--- a/frontend/src/components/pages/TargetDetails/index.tsx
+++ b/frontend/src/components/pages/TargetDetails/index.tsx
@@ -193,7 +193,11 @@ const TargetDetails: React.FC<Props> = ({
             expandedRowRender: (record) => (
               <Space direction="vertical" style={{ paddingLeft: "48px" }}>
                 <strong>Failure Message:</strong>
-                <pre style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{record.failureMessage}</pre>
+                <pre
+                  style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}
+                >
+                  {record.failureMessage}
+                </pre>
               </Space>
             ),
           }}


### PR DESCRIPTION
I have noticed that in a couple of text blocks, long lines were not wrapped leading to text getting out of the panels. Please see the images attached (`Failure Message` panels):

<img width="3783" height="1860" alt="image" src="https://github.com/user-attachments/assets/0fc6cf42-b47b-4c02-8a96-0920ac4a3d38" />

<img width="3746" height="1731" alt="image" src="https://github.com/user-attachments/assets/644f5673-8fa1-456d-9cdd-7ceeaa876020" />

There are a few more places where no style is applied, but I am not seeing any poorly rendered text blocks. If I discover this happens in other places, I'll submit a separate PR.

I believe this style change should be robust, but please advise if there's better way to achieve prettier formatting in `pre` elements.