### PR TITLE
Allow partial invocation metadata parsing

### DIFF
--- a/internal/database/buildeventrecorder/BUILD.bazel
+++ b/internal/database/buildeventrecorder/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//internal/database/sqlc",
         "//pkg/authmetadataextraction",
         "//pkg/invocation",
+        "//pkg/invocationmetadataextraction",
         "//pkg/prometheus_metrics",
         "//pkg/proto/bazelbuild/bazel/bes:build_event_stream",
         "//pkg/proto/bazelbuild/bazel/protobuf:src_main_protobuf",

--- a/internal/database/buildeventrecorder/save_structured_command_line.go
+++ b/internal/database/buildeventrecorder/save_structured_command_line.go
@@ -2,8 +2,6 @@ package buildeventrecorder
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"slices"
 	"sort"
 	"strings"
@@ -15,27 +13,11 @@ import (
 	"github.com/buildbarn/bb-portal/internal/database"
 	"github.com/buildbarn/bb-portal/internal/database/common"
 	"github.com/buildbarn/bb-portal/pkg/invocation"
+	"github.com/buildbarn/bb-portal/pkg/invocationmetadataextraction"
 	"github.com/buildbarn/bb-storage/pkg/util"
 
 	bes "github.com/bazelbuild/bazel/src/main/protobuf"
 )
-
-type sourceControl struct {
-	Repo      *string `json:"repo,omitempty"`
-	RepoURL   *string `json:"repoUrl,omitempty"`
-	Ref       *string `json:"ref,omitempty"`
-	RefURL    *string `json:"refUrl,omitempty"`
-	Commit    *string `json:"commit,omitempty"`
-	CommitURL *string `json:"commitUrl,omitempty"`
-}
-
-type invocationMetadata struct {
-	Username       *string           `json:"username,omitempty"`
-	Hostname       *string           `json:"hostname,omitempty"`
-	SourceControls []sourceControl   `json:"sourceControls,omitempty"`
-	InvocationTags map[string]string `json:"invocationTags,omitempty"`
-	BuildTags      map[string]string `json:"buildTags,omitempty"`
-}
 
 func parseEnvVarsFromSectionOptions(section *bes.CommandLineSection) map[string]string {
 	if section.GetOptionList() == nil {
@@ -75,40 +57,7 @@ func parseProfileNameFromSectionOptions(section *bes.CommandLineSection) string 
 	return "command.profile.gz"
 }
 
-func (r *buildEventRecorder) extractInvocationMetadata(envVars map[string]string) (*invocationMetadata, error) {
-	extractor := r.dataExtractors.InvocationMetadataExtractor
-	if extractor == nil {
-		return nil, nil
-	}
-
-	// Convert map[string]string to map[string]any that the extractor needs
-	searchVars := make(map[string]any, len(envVars))
-	for k, v := range envVars {
-		searchVars[k] = v
-	}
-
-	searchResult, err := extractor.Search(map[string]any{
-		"env": searchVars,
-	})
-	if err != nil {
-		return nil, nil
-	}
-
-	// Convert map[string]any to JSON bytes
-	jsonBytes, err := json.Marshal(searchResult)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal search result: %w", err)
-	}
-
-	// Unmarshal into the pointer-based struct
-	var metadata invocationMetadata
-	if err := json.Unmarshal(jsonBytes, &metadata); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal into InvocationMetadata: %w", err)
-	}
-	return &metadata, nil
-}
-
-func (r *buildEventRecorder) recordSourceControl(ctx context.Context, tx *ent.Client, sourceControls []sourceControl) error {
+func (r *buildEventRecorder) recordSourceControl(ctx context.Context, tx *ent.Client, sourceControls []invocationmetadataextraction.SourceControl) error {
 	scBuilders := make([]*ent.SourceControlCreate, 0, len(sourceControls))
 	for _, sc := range sourceControls {
 		create := tx.SourceControl.Create().SetBazelInvocationID(r.InvocationDbID)
@@ -180,7 +129,7 @@ func (r *buildEventRecorder) recordBuildTags(ctx context.Context, tx *ent.Client
 	return nil
 }
 
-func (r *buildEventRecorder) recordBuild(ctx context.Context, tx database.Tx, invocationMetadata *invocationMetadata) error {
+func (r *buildEventRecorder) recordBuild(ctx context.Context, tx database.Tx, invocationMetadata *invocationmetadataextraction.InvocationMetadata) error {
 	if r.buildKey == "" {
 		return nil
 	}
@@ -256,10 +205,7 @@ func (r *buildEventRecorder) saveStructuredCommandLine(ctx context.Context, tx d
 			SetProfileName(profileName).
 			SetCanonicalCommandLine(&data)
 
-		invocationMetadata, err := r.extractInvocationMetadata(envVars)
-		if err != nil {
-			return util.StatusWrap(err, "Failed get invocation metadata from environment variables")
-		}
+		invocationMetadata := invocationmetadataextraction.ExtractInvocationMetadata(r.dataExtractors.InvocationMetadataExtractor, envVars)
 		if invocationMetadata != nil {
 			if username := invocationMetadata.Username; username != nil && *username != "" {
 				update.SetUsername(*username)
@@ -278,7 +224,7 @@ func (r *buildEventRecorder) saveStructuredCommandLine(ctx context.Context, tx d
 				return util.StatusWrap(err, "Failed to record invocation tags")
 			}
 		}
-		if err = update.Exec(ctx); err != nil {
+		if err := update.Exec(ctx); err != nil {
 			return util.StatusWrapf(err, "Failed to update invocation with data from StructuredCommandLine event")
 		}
 	case "original":

--- a/pkg/invocationmetadataextraction/BUILD.bazel
+++ b/pkg/invocationmetadataextraction/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "invocationmetadataextraction",
+    srcs = ["metadata_extraction.go"],
+    importpath = "github.com/buildbarn/bb-portal/pkg/invocationmetadataextraction",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_buildbarn_bb_storage//pkg/jmespath"],
+)
+
+go_test(
+    name = "invocationmetadataextraction_test",
+    srcs = ["metadata_extraction_test.go"],
+    deps = [
+        ":invocationmetadataextraction",
+        "@com_github_buildbarn_bb_storage//pkg/clock",
+        "@com_github_buildbarn_bb_storage//pkg/jmespath",
+        "@com_github_buildbarn_bb_storage//pkg/proto/configuration/jmespath",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/invocationmetadataextraction/metadata_extraction.go
+++ b/pkg/invocationmetadataextraction/metadata_extraction.go
@@ -1,0 +1,126 @@
+package invocationmetadataextraction
+
+import (
+	"github.com/buildbarn/bb-storage/pkg/jmespath"
+)
+
+// SourceControl contains source control data for a invocation
+type SourceControl struct {
+	Repo      *string
+	RepoURL   *string
+	Ref       *string
+	RefURL    *string
+	Commit    *string
+	CommitURL *string
+}
+
+// InvocationMetadata contains metadata for a invocation
+type InvocationMetadata struct {
+	Username       *string
+	Hostname       *string
+	SourceControls []SourceControl
+	InvocationTags map[string]string
+	BuildTags      map[string]string
+}
+
+// NewInvocationMetadata creates a new empty InvocationMetadata
+func NewInvocationMetadata() *InvocationMetadata {
+	return &InvocationMetadata{
+		Username:       nil,
+		Hostname:       nil,
+		SourceControls: []SourceControl{},
+		InvocationTags: map[string]string{},
+		BuildTags:      map[string]string{},
+	}
+}
+
+func parseSourceControlMap(sc map[string]any) *SourceControl {
+	if sc == nil {
+		return nil
+	}
+
+	shouldSave := false
+
+	getField := func(key string) *string {
+		if value, ok := sc[key].(string); ok && value != "" {
+			shouldSave = true
+			return &value
+		}
+		return nil
+	}
+
+	scStruct := SourceControl{
+		Repo:      getField("repo"),
+		RepoURL:   getField("repoUrl"),
+		Ref:       getField("ref"),
+		RefURL:    getField("refUrl"),
+		Commit:    getField("commit"),
+		CommitURL: getField("commitUrl"),
+	}
+
+	if !shouldSave {
+		return nil
+	}
+
+	return &scStruct
+}
+
+// ExtractInvocationMetadata extracts invocation metadata from the environment
+// variables using the provided JMESPath expression.
+func ExtractInvocationMetadata(extractor *jmespath.Expression, envVars map[string]string) *InvocationMetadata {
+	if extractor == nil {
+		return nil
+	}
+
+	// Convert map[string]string to map[string]any that the extractor needs
+	searchVars := make(map[string]any, len(envVars))
+	for k, v := range envVars {
+		searchVars[k] = v
+	}
+
+	searchResults, err := extractor.Search(map[string]any{
+		"env": searchVars,
+	})
+	if err != nil || searchResults == nil {
+		return nil
+	}
+
+	resMap, ok := searchResults.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	metadata := NewInvocationMetadata()
+
+	if username, ok := resMap["username"].(string); ok && username != "" {
+		metadata.Username = &username
+	}
+	if hostname, ok := resMap["hostname"].(string); ok && hostname != "" {
+		metadata.Hostname = &hostname
+	}
+	if sourceControls, ok := resMap["sourceControls"].([]any); ok {
+		for _, sourceControl := range sourceControls {
+			if sc, ok := sourceControl.(map[string]any); ok {
+				if scres := parseSourceControlMap(sc); scres != nil {
+					metadata.SourceControls = append(metadata.SourceControls, *scres)
+				}
+			}
+		}
+	}
+	if invocationTags, ok := resMap["invocationTags"].(map[string]any); ok {
+		for key, anyValue := range invocationTags {
+			if value, ok := anyValue.(string); ok && value != "" {
+				metadata.InvocationTags[key] = value
+			}
+		}
+	}
+	if buildTags, ok := resMap["buildTags"].(map[string]any); ok {
+		for key, anyValue := range buildTags {
+			if value, ok := anyValue.(string); ok && value != "" {
+				metadata.BuildTags[key] = value
+			}
+		}
+	}
+
+	return metadata
+}

--- a/pkg/invocationmetadataextraction/metadata_extraction_test.go
+++ b/pkg/invocationmetadataextraction/metadata_extraction_test.go
@@ -1,0 +1,406 @@
+package invocationmetadataextraction_test
+
+import (
+	"testing"
+
+	"github.com/buildbarn/bb-portal/pkg/invocationmetadataextraction"
+	"github.com/buildbarn/bb-storage/pkg/clock"
+	"github.com/buildbarn/bb-storage/pkg/jmespath"
+	jmespath_config "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath"
+	"github.com/stretchr/testify/require"
+)
+
+func ptr(s string) *string {
+	return &s
+}
+
+func extractorFromExpression(t *testing.T, expression string) *jmespath.Expression {
+	jmespathExpression := &jmespath_config.Expression{
+		Expression: expression,
+	}
+	extractor, err := jmespath.NewExpressionFromConfiguration(jmespathExpression, nil, clock.SystemClock)
+	require.NoError(t, err)
+	return extractor
+}
+
+func TestInvocationMetadataExtraction(t *testing.T) {
+	fullExtractor := extractorFromExpression(t, `{
+		"username": env.USER
+		"hostname": env.HOSTNAME
+		"sourceControls": [
+			{
+			"repo": env.REPO_1
+			"repoUrl": env.REPO_URL_1
+			"ref": env.REF_1
+			"refUrl": env.REF_URL_1
+			"commit": env.COMMIT_1
+			"commitUrl": env.COMMIT_URL_1
+			"dummyKey": env.DUMMY_VALUE
+			},
+			{
+			"repo": env.REPO_2
+			"repoUrl": env.REPO_URL_2
+			"ref": env.REF_2
+			"refUrl": env.REF_URL_2
+			"commit": env.COMMIT_2
+			"commitUrl": env.COMMIT_URL_2
+			"dummyKey": env.DUMMY_VALUE
+			}
+		]
+		"invocationTags": {
+			"invTag1": env.INV_TAG_1
+			"invTag2": env.INV_TAG_2
+		}
+		"buildTags": {
+			"buildTag1": env.BUILD_TAG_1
+			"buildTag2": env.BUILD_TAG_2
+		}
+		"dummyKey": env.DUMMY_VALUE
+	}`)
+
+	t.Run("NoExpression", func(t *testing.T) {
+		extractor := extractorFromExpression(t, `{
+			"foo": "bar"
+		}`)
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(extractor, map[string]string{
+			"USER":     "user",
+			"HOSTNAME": "hostname",
+		})
+		require.Equal(t, invocationmetadataextraction.NewInvocationMetadata(), metadata)
+	})
+
+	t.Run("NoData", func(t *testing.T) {
+		extractor := extractorFromExpression(t, `{
+			"username": env.USER
+			"hostname": env.HOSTNAME
+		}`)
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(extractor, map[string]string{})
+		require.Equal(t, invocationmetadataextraction.NewInvocationMetadata(), metadata)
+	})
+
+	t.Run("MissingUsername", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"HOSTNAME":     "hostname",
+			"REPO_1":       "repo1",
+			"REPO_URL_1":   "repoUrl1",
+			"REF_1":        "ref1",
+			"REF_URL_1":    "refUrl1",
+			"COMMIT_1":     "commit1",
+			"COMMIT_URL_1": "commitUrl1",
+			"REPO_2":       "repo2",
+			"REPO_URL_2":   "repoUrl2",
+			"REF_2":        "ref2",
+			"REF_URL_2":    "refUrl2",
+			"COMMIT_2":     "commit2",
+			"COMMIT_URL_2": "commitUrl2",
+			"INV_TAG_1":    "invTag1",
+			"INV_TAG_2":    "invTag2",
+			"BUILD_TAG_1":  "buildTag1",
+			"BUILD_TAG_2":  "buildTag2",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username: nil,
+			Hostname: ptr("hostname"),
+			SourceControls: []invocationmetadataextraction.SourceControl{
+				{
+					Repo:      ptr("repo1"),
+					RepoURL:   ptr("repoUrl1"),
+					Ref:       ptr("ref1"),
+					RefURL:    ptr("refUrl1"),
+					Commit:    ptr("commit1"),
+					CommitURL: ptr("commitUrl1"),
+				},
+				{
+					Repo:      ptr("repo2"),
+					RepoURL:   ptr("repoUrl2"),
+					Ref:       ptr("ref2"),
+					RefURL:    ptr("refUrl2"),
+					Commit:    ptr("commit2"),
+					CommitURL: ptr("commitUrl2"),
+				},
+			},
+			InvocationTags: map[string]string{
+				"invTag1": "invTag1",
+				"invTag2": "invTag2",
+			},
+			BuildTags: map[string]string{
+				"buildTag1": "buildTag1",
+				"buildTag2": "buildTag2",
+			},
+		}, metadata)
+	})
+
+	t.Run("MissingHostname", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"USER":         "user",
+			"REPO_1":       "repo1",
+			"REPO_URL_1":   "repoUrl1",
+			"REF_1":        "ref1",
+			"REF_URL_1":    "refUrl1",
+			"COMMIT_1":     "commit1",
+			"COMMIT_URL_1": "commitUrl1",
+			"REPO_2":       "repo2",
+			"REPO_URL_2":   "repoUrl2",
+			"REF_2":        "ref2",
+			"REF_URL_2":    "refUrl2",
+			"COMMIT_2":     "commit2",
+			"COMMIT_URL_2": "commitUrl2",
+			"INV_TAG_1":    "invTag1",
+			"INV_TAG_2":    "invTag2",
+			"BUILD_TAG_1":  "buildTag1",
+			"BUILD_TAG_2":  "buildTag2",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username: ptr("user"),
+			Hostname: nil,
+			SourceControls: []invocationmetadataextraction.SourceControl{
+				{
+					Repo:      ptr("repo1"),
+					RepoURL:   ptr("repoUrl1"),
+					Ref:       ptr("ref1"),
+					RefURL:    ptr("refUrl1"),
+					Commit:    ptr("commit1"),
+					CommitURL: ptr("commitUrl1"),
+				},
+				{
+					Repo:      ptr("repo2"),
+					RepoURL:   ptr("repoUrl2"),
+					Ref:       ptr("ref2"),
+					RefURL:    ptr("refUrl2"),
+					Commit:    ptr("commit2"),
+					CommitURL: ptr("commitUrl2"),
+				},
+			},
+			InvocationTags: map[string]string{
+				"invTag1": "invTag1",
+				"invTag2": "invTag2",
+			},
+			BuildTags: map[string]string{
+				"buildTag1": "buildTag1",
+				"buildTag2": "buildTag2",
+			},
+		}, metadata)
+	})
+
+	t.Run("MissingSourceControl", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"USER":        "user",
+			"HOSTNAME":    "hostname",
+			"INV_TAG_1":   "invTag1",
+			"INV_TAG_2":   "invTag2",
+			"BUILD_TAG_1": "buildTag1",
+			"BUILD_TAG_2": "buildTag2",
+			"DUMMY_VALUE": "dummyValue",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username:       ptr("user"),
+			Hostname:       ptr("hostname"),
+			SourceControls: []invocationmetadataextraction.SourceControl{},
+			InvocationTags: map[string]string{
+				"invTag1": "invTag1",
+				"invTag2": "invTag2",
+			},
+			BuildTags: map[string]string{
+				"buildTag1": "buildTag1",
+				"buildTag2": "buildTag2",
+			},
+		}, metadata)
+	})
+
+	t.Run("SingleSourceControl", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"USER":         "user",
+			"HOSTNAME":     "hostname",
+			"REPO_1":       "repo1",
+			"REPO_URL_1":   "repoUrl1",
+			"REF_1":        "ref1",
+			"REF_URL_1":    "refUrl1",
+			"COMMIT_1":     "commit1",
+			"COMMIT_URL_1": "commitUrl1",
+			"INV_TAG_1":    "invTag1",
+			"INV_TAG_2":    "invTag2",
+			"BUILD_TAG_1":  "buildTag1",
+			"BUILD_TAG_2":  "buildTag2",
+			"DUMMY_VALUE":  "dummyValue",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username: ptr("user"),
+			Hostname: ptr("hostname"),
+			SourceControls: []invocationmetadataextraction.SourceControl{
+				{
+					Repo:      ptr("repo1"),
+					RepoURL:   ptr("repoUrl1"),
+					Ref:       ptr("ref1"),
+					RefURL:    ptr("refUrl1"),
+					Commit:    ptr("commit1"),
+					CommitURL: ptr("commitUrl1"),
+				},
+			},
+			InvocationTags: map[string]string{
+				"invTag1": "invTag1",
+				"invTag2": "invTag2",
+			},
+			BuildTags: map[string]string{
+				"buildTag1": "buildTag1",
+				"buildTag2": "buildTag2",
+			},
+		}, metadata)
+	})
+
+	t.Run("MissingInvocationTags", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"USER":         "user",
+			"HOSTNAME":     "hostname",
+			"REPO_1":       "repo1",
+			"REPO_URL_1":   "repoUrl1",
+			"REF_1":        "ref1",
+			"REF_URL_1":    "refUrl1",
+			"COMMIT_1":     "commit1",
+			"COMMIT_URL_1": "commitUrl1",
+			"REPO_2":       "repo2",
+			"REPO_URL_2":   "repoUrl2",
+			"REF_2":        "ref2",
+			"REF_URL_2":    "refUrl2",
+			"COMMIT_2":     "commit2",
+			"COMMIT_URL_2": "commitUrl2",
+			"BUILD_TAG_1":  "buildTag1",
+			"BUILD_TAG_2":  "buildTag2",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username: ptr("user"),
+			Hostname: ptr("hostname"),
+			SourceControls: []invocationmetadataextraction.SourceControl{
+				{
+					Repo:      ptr("repo1"),
+					RepoURL:   ptr("repoUrl1"),
+					Ref:       ptr("ref1"),
+					RefURL:    ptr("refUrl1"),
+					Commit:    ptr("commit1"),
+					CommitURL: ptr("commitUrl1"),
+				},
+				{
+					Repo:      ptr("repo2"),
+					RepoURL:   ptr("repoUrl2"),
+					Ref:       ptr("ref2"),
+					RefURL:    ptr("refUrl2"),
+					Commit:    ptr("commit2"),
+					CommitURL: ptr("commitUrl2"),
+				},
+			},
+			InvocationTags: map[string]string{},
+			BuildTags: map[string]string{
+				"buildTag1": "buildTag1",
+				"buildTag2": "buildTag2",
+			},
+		}, metadata)
+	})
+
+	t.Run("MissingBuildTags", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"USER":         "user",
+			"HOSTNAME":     "hostname",
+			"REPO_1":       "repo1",
+			"REPO_URL_1":   "repoUrl1",
+			"REF_1":        "ref1",
+			"REF_URL_1":    "refUrl1",
+			"COMMIT_1":     "commit1",
+			"COMMIT_URL_1": "commitUrl1",
+			"REPO_2":       "repo2",
+			"REPO_URL_2":   "repoUrl2",
+			"REF_2":        "ref2",
+			"REF_URL_2":    "refUrl2",
+			"COMMIT_2":     "commit2",
+			"COMMIT_URL_2": "commitUrl2",
+			"INV_TAG_1":    "invTag1",
+			"INV_TAG_2":    "invTag2",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username: ptr("user"),
+			Hostname: ptr("hostname"),
+			SourceControls: []invocationmetadataextraction.SourceControl{
+				{
+					Repo:      ptr("repo1"),
+					RepoURL:   ptr("repoUrl1"),
+					Ref:       ptr("ref1"),
+					RefURL:    ptr("refUrl1"),
+					Commit:    ptr("commit1"),
+					CommitURL: ptr("commitUrl1"),
+				},
+				{
+					Repo:      ptr("repo2"),
+					RepoURL:   ptr("repoUrl2"),
+					Ref:       ptr("ref2"),
+					RefURL:    ptr("refUrl2"),
+					Commit:    ptr("commit2"),
+					CommitURL: ptr("commitUrl2"),
+				},
+			},
+			InvocationTags: map[string]string{
+				"invTag1": "invTag1",
+				"invTag2": "invTag2",
+			},
+			BuildTags: map[string]string{},
+		}, metadata)
+	})
+
+	t.Run("FullDataWithDummyValues", func(t *testing.T) {
+		metadata := invocationmetadataextraction.ExtractInvocationMetadata(fullExtractor, map[string]string{
+			"USER":         "user",
+			"HOSTNAME":     "hostname",
+			"REPO_1":       "repo1",
+			"REPO_URL_1":   "repoUrl1",
+			"REF_1":        "ref1",
+			"REF_URL_1":    "refUrl1",
+			"COMMIT_1":     "commit1",
+			"COMMIT_URL_1": "commitUrl1",
+			"REPO_2":       "repo2",
+			"REPO_URL_2":   "repoUrl2",
+			"REF_2":        "ref2",
+			"REF_URL_2":    "refUrl2",
+			"COMMIT_2":     "commit2",
+			"COMMIT_URL_2": "commitUrl2",
+			"INV_TAG_1":    "invTag1",
+			"INV_TAG_2":    "invTag2",
+			"BUILD_TAG_1":  "buildTag1",
+			"BUILD_TAG_2":  "buildTag2",
+			"DUMMY_VALUE":  "dummyValue",
+		})
+
+		require.Equal(t, &invocationmetadataextraction.InvocationMetadata{
+			Username: ptr("user"),
+			Hostname: ptr("hostname"),
+			SourceControls: []invocationmetadataextraction.SourceControl{
+				{
+					Repo:      ptr("repo1"),
+					RepoURL:   ptr("repoUrl1"),
+					Ref:       ptr("ref1"),
+					RefURL:    ptr("refUrl1"),
+					Commit:    ptr("commit1"),
+					CommitURL: ptr("commitUrl1"),
+				},
+				{
+					Repo:      ptr("repo2"),
+					RepoURL:   ptr("repoUrl2"),
+					Ref:       ptr("ref2"),
+					RefURL:    ptr("refUrl2"),
+					Commit:    ptr("commit2"),
+					CommitURL: ptr("commitUrl2"),
+				},
+			},
+			InvocationTags: map[string]string{
+				"invTag1": "invTag1",
+				"invTag2": "invTag2",
+			},
+			BuildTags: map[string]string{
+				"buildTag1": "buildTag1",
+				"buildTag2": "buildTag2",
+			},
+		}, metadata)
+	})
+}


### PR DESCRIPTION
Instead of parsing the data via json, we do the data extraction ourselves. This allows us to gracefully handle partial data better. Also add tests to make sure that invocation metadata parsing works correctly.