### PR TITLE
Fix in progress invocations reload flash

### DIFF
--- a/frontend/src/components/BazelInvocation/index.tsx
+++ b/frontend/src/components/BazelInvocation/index.tsx
@@ -282,7 +282,7 @@ const getTitleBits = (
   const titleBits: React.ReactNode[] = [];
   if (username && username !== "")
     titleBits.push(
-      <span key="label">
+      <span key="username">
         User:{" "}
         <Typography.Text type="secondary" className={styles.normalWeight}>
           <UserStatusIndicator
@@ -294,7 +294,7 @@ const getTitleBits = (
     );
   if (invocationID && invocationID !== "")
     titleBits.push(
-      <span key="label">
+      <span key="invocationID">
         Invocation ID:{" "}
         <Typography.Text
           type="secondary"

--- a/frontend/src/components/pages/BazelInvocationDetails/index.tsx
+++ b/frontend/src/components/pages/BazelInvocationDetails/index.tsx
@@ -47,7 +47,7 @@ const PageContent: React.FC<Params> = ({ invocationID }) => {
     }
   }, [invocation, stopPolling]);
 
-  if (loading) {
+  if (loading && !data) {
     return (
       <PortalCard icon={<BuildOutlined />} titleBits={["Bazel Invocation"]}>
         <Spin />


### PR DESCRIPTION
NOTE: This is a stacked PR. Please merge #243 first.

The automatic reload for invocations that are in progress caused a visible flash when the content was reloaded.