### PR TITLE
Create a single sourc of truth for darkmode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,11 +7,14 @@
     <!-- BB_PORTAL_CONFIGURATION_PLACEHOLDER -->
     <script>
       (() => {
+        const prefersColorShemeDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         try {
           const key = 'prefers-dark';
-          const isDark = localStorage.getItem(key) === 'true' || (!localStorage.getItem(key) && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          const isDark = localStorage.getItem(key) === 'true' || (!localStorage.getItem(key) && prefersColorShemeDark);
           document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-        } catch (_e) {}
+        } catch (_e) {
+          document.documentElement.setAttribute('data-theme', prefersColorShemeDark ? 'dark' : 'light');
+        }
       })();
     </script>
   </head>

--- a/frontend/src/components/pages/RootLayout/index.tsx
+++ b/frontend/src/components/pages/RootLayout/index.tsx
@@ -4,7 +4,7 @@ import { ReactQueryDevtoolsPanel } from "@tanstack/react-query-devtools";
 import { Outlet } from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { ConfigProvider, Layout } from "antd";
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { ApolloWrapper } from "@/components/ApolloWrapper";
 import AppBar from "@/components/AppBar";
 import GrpcClientsProvider from "@/context/GrpcClientsProvider";
@@ -12,65 +12,37 @@ import { Status } from "@/lib/grpc-client/google/rpc/status";
 import dark from "@/theme/dark";
 import light from "@/theme/light";
 import { isRetryableGrpcError } from "@/utils/grpcStatus";
-import parseStringBoolean from "@/utils/storage";
 import styles from "./index.module.css";
 
 const PREFERS_DARK_KEY = "prefers-dark";
 
-function windowDefined(): boolean {
-  return typeof window !== "undefined";
+function getTheme(): "dark" | "light" {
+  return document.documentElement.getAttribute("data-theme") === "dark"
+    ? "dark"
+    : "light";
 }
 
-function calculatePrefersDark(): boolean {
-  if (windowDefined()) {
-    const prefersDark = window.localStorage.getItem(PREFERS_DARK_KEY);
-    if (prefersDark) {
-      return parseStringBoolean(prefersDark);
-    }
-  }
-  return browserPrefersDark();
-}
-
-function browserPrefersDark(): boolean {
-  if (windowDefined()) {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches;
-  }
-  return false;
-}
-
-function savePrefersDark(prefersDark: boolean): void {
-  if (windowDefined()) {
-    window.localStorage.setItem(
-      PREFERS_DARK_KEY,
-      prefersDark ? "true" : "false",
-    );
-    window.localStorage.setItem(
-      "graphiql:theme",
-      prefersDark ? "dark" : "light",
-    );
-  }
+function setTheme(theme: "dark" | "light") {
+  window.localStorage.setItem(
+    PREFERS_DARK_KEY,
+    theme === "dark" ? "true" : "false",
+  );
+  document.documentElement.setAttribute("data-theme", theme);
 }
 
 export const RootLayout = () => {
-  const [prefersDark, setPrefersDark] = useState<boolean>(
-    calculatePrefersDark(),
-  );
-  const theme = prefersDark ? dark : light;
+  // Inner theme is a meaningless state used to force rerender when we modify the html tag.
+  const [innerTheme, setInnerTheme] = useState(() => getTheme());
 
   useLayoutEffect(() => {
     document.getElementById("splash")?.remove();
   }, []);
 
-  useEffect(() => {
-    const val = calculatePrefersDark();
-    setPrefersDark(val);
-  }, []);
-
   const toggleTheme = useCallback(() => {
-    const opposite = !prefersDark;
-    savePrefersDark(opposite);
-    setPrefersDark(opposite);
-  }, [prefersDark]);
+    const opposite = getTheme() === "dark" ? "light" : "dark";
+    setTheme(opposite);
+    setInnerTheme(opposite);
+  }, []);
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -86,11 +58,14 @@ export const RootLayout = () => {
   });
   return (
     <ApolloWrapper>
-      <ConfigProvider theme={theme}>
+      <ConfigProvider theme={innerTheme === "dark" ? dark : light}>
         <QueryClientProvider client={queryClient}>
           <GrpcClientsProvider>
             <Layout className={styles.layout}>
-              <AppBar toggleTheme={toggleTheme} prefersDark={prefersDark} />
+              <AppBar
+                toggleTheme={toggleTheme}
+                prefersDark={innerTheme === "dark"}
+              />
               <Outlet />
             </Layout>
           </GrpcClientsProvider>

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -65,37 +65,35 @@ pre {
   word-wrap: break-word;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
+[data-theme="dark"] {
+  --foreground-rgb: 255, 255, 255;
+  --background-start-rgb: 0, 0, 0;
+  --background-end-rgb: 0, 0, 0;
 
-    --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
-    --secondary-glow: linear-gradient(
-      to bottom right,
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0),
-      rgba(1, 65, 255, 0.3)
-    );
+  --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
+  --secondary-glow: linear-gradient(
+    to bottom right,
+    rgba(1, 65, 255, 0),
+    rgba(1, 65, 255, 0),
+    rgba(1, 65, 255, 0.3)
+  );
 
-    --tile-start-rgb: 2, 13, 46;
-    --tile-end-rgb: 2, 5, 19;
-    --tile-border: conic-gradient(
-      #ffffff80,
-      #ffffff40,
-      #ffffff30,
-      #ffffff20,
-      #ffffff10,
-      #ffffff10,
-      #ffffff80
-    );
+  --tile-start-rgb: 2, 13, 46;
+  --tile-end-rgb: 2, 5, 19;
+  --tile-border: conic-gradient(
+    #ffffff80,
+    #ffffff40,
+    #ffffff30,
+    #ffffff20,
+    #ffffff10,
+    #ffffff10,
+    #ffffff80
+  );
 
-    --callout-rgb: 20, 20, 20;
-    --callout-border-rgb: 108, 108, 108;
-    --card-rgb: 100, 100, 100;
-    --card-border-rgb: 200, 200, 200;
-  }
+  --callout-rgb: 20, 20, 20;
+  --callout-border-rgb: 108, 108, 108;
+  --card-rgb: 100, 100, 100;
+  --card-border-rgb: 200, 200, 200;
 }
 
 * {
@@ -115,8 +113,6 @@ body {
   overflow-x: hidden;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+[data-theme="dark"] {
+  color-scheme: dark;
 }

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,5 +1,0 @@
-const parseStringBoolean = (val: string | null): boolean => {
-  return val === "true";
-};
-
-export default parseStringBoolean;


### PR DESCRIPTION
NOTE: This is a stacked PR. Please merge #245 first.

Dark mode had several sources of truth, which meant .css variables were not set correctly if the dark mode button was used but the browser settings were set to light mode.

Ensure that dark mode has a single source of truth; data-theme.

Ensure that [data-theme="dark"] can be used in .css to detect dark mode, and that dark mode variables are always set as expected.

Fix issues where toggling dark mode with the button and with browser setting can have different and unexpected results.