### PR TITLE
Fix empty Trends chart: XAxis dataKey points to nonexistent field

### DIFF
--- a/frontend/src/components/pages/Trends/index.tsx
+++ b/frontend/src/components/pages/Trends/index.tsx
@@ -166,8 +166,17 @@ export const TrendsPage: React.FC = () => {
                       <stop offset="95%" stopColor="#8884d8" stopOpacity={0} />
                     </linearGradient>
                   </defs>
-                  <XAxis dataKey="name" />
-                  <YAxis />
+                  <XAxis
+                    dataKey="from"
+                    tickFormatter={(v: string) =>
+                      new Date(v).toLocaleDateString()
+                    }
+                  />
+                  <YAxis
+                    tickFormatter={(v: number) =>
+                      readableDurationFromMilliseconds(v, { smallestUnit: "s" })
+                    }
+                  />
                   <CartesianGrid vertical={false} strokeDasharray="3 3" />
                   <Tooltip />
                   <Area


### PR DESCRIPTION
## Problem

On the Trends page, the invocation-durations chart renders only the YAxis (often with a "first tick" in the hundreds of thousands of milliseconds) and no Area. The summary stats (Total / Avg / Median / Max / Min) render correctly.

## Root cause

`frontend/src/components/pages/Trends/index.tsx` declares:

```tsx
<XAxis dataKey="name" />
```

But `dataPoints` only contains `invocationId`, `from`, `to`, and `duration` — there is no `name` field. So the XAxis dataKey resolves to `undefined` for every row.

This has been the code since the original Trends PR (#14), but it rendered correctly under recharts v2: a category XAxis with an undefined dataKey silently fell back to row-index positioning. After commit 256ecfa ("Build frontend with Vite instead of Nextjs") bumped recharts from `^2.12.7` to `^3.8.0`, the v3 axis logic collapses all points to a single undefined category bucket, so the Area degenerates and the chart appears empty. The YAxis is unaffected and still auto-scales to the duration range — hence the lonely "450000"-style tick.

## Fix

Point XAxis at `from` (the invocation start timestamp) so points are chronologically ordered, and format both axes for readability:

- X ticks as locale dates
- Y ticks via `readableDurationFromMilliseconds` (smallestUnit: `"s"`)

## Verification

- `npx biome check` clean
- `npx tsc --noEmit` clean
- Have not yet loaded the rebuilt frontend in a browser — happy to attach a screenshot if a maintainer can point me at the preferred local-dev path, or I can verify against our internal deployment and report back.