### PR TITLE
Tag selection management

### DIFF
--- a/frontend/src/components/BazelInvocationColumns/Columns.tsx
+++ b/frontend/src/components/BazelInvocationColumns/Columns.tsx
@@ -6,6 +6,7 @@ import dayjs from "dayjs";
 import { validate as uuidValidate } from "uuid";
 import PortalDuration from "@/components/PortalDuration";
 import {
+  FilterPickerDropdown,
   SearchFilterIcon,
   SearchWidget,
   TimeRangeSelector,
@@ -127,6 +128,7 @@ export const statusColumn: TableColumnTypeWithFilter<
   filterIcon: (filtered) => (
     <SearchFilterIcon icon={<SearchOutlined />} filtered={filtered} />
   ),
+  filterDropdown: (filterProps) => <FilterPickerDropdown {...filterProps} />,
   filters: invocationResultTagFilters,
   applyFilter: applyInvocationResultTagFilter,
 };

--- a/frontend/src/components/SearchWidgets/index.module.css
+++ b/frontend/src/components/SearchWidgets/index.module.css
@@ -24,3 +24,32 @@
 .searchWidgetButtonsSpacing {
   flex: auto;
 }
+
+.searchWidgetCheckBoxItem {
+  padding: 2px 8px;
+  display: flex;
+  border-radius: 4px;
+}
+
+.searchWidgetCheckBoxItem:hover {
+  background-color: rgb(var(--callout-rgb));
+}
+
+.searchWidgetCheckBoxItemActive {
+  background-color: #e6f4ff;
+}
+.searchWidgetCheckBoxItemActive:hover {
+  background-color: #bae0ff;
+}
+
+[data-theme="dark"] {
+  .searchWidgetCheckBoxItem:hover {
+    background-color: rgba(225, 225, 225, 0.08);
+  }
+  .searchWidgetCheckBoxItemActive {
+    background-color: #15325b;
+  }
+  .searchWidgetCheckBoxItemActive:hover {
+    background-color: #15417e;
+  }
+}

--- a/frontend/src/components/SearchWidgets/index.tsx
+++ b/frontend/src/components/SearchWidgets/index.tsx
@@ -1,8 +1,10 @@
 import { blue } from "@ant-design/colors";
 import {
   Button,
+  Checkbox,
   DatePicker,
   Divider,
+  Flex,
   Input,
   Space,
   type TimeRangePickerProps,
@@ -167,6 +169,74 @@ export const SearchWidget: React.FC<InputFilterProps> = ({
         </Tooltip>
       </div>
     </Space>
+  );
+};
+
+export const FilterPickerDropdown: React.FC<FilterDropdownProps> = ({
+  filters,
+  setSelectedKeys,
+  selectedKeys,
+  confirm,
+  clearFilters,
+}) => {
+  return (
+    <Space.Compact direction="vertical">
+      <Space direction="vertical" style={{ padding: "4px" }} size={2}>
+        {filters?.map((filter) => (
+          <Checkbox
+            key={filter.value.toString()}
+            checked={selectedKeys.includes(filter.value.toString())}
+            onChange={(e) => {
+              if (e.target.checked) {
+                setSelectedKeys([
+                  ...selectedKeys,
+                  filter.value.toString() || "",
+                ]);
+              } else {
+                setSelectedKeys(
+                  selectedKeys.filter((key) => key !== filter.value.toString()),
+                );
+              }
+            }}
+            className={`${styles.searchWidgetCheckBoxItem} ${
+              selectedKeys.includes(filter.value.toString())
+                ? styles.searchWidgetCheckBoxItemActive
+                : ""
+            }`}
+          >
+            {filter.text}
+          </Checkbox>
+        ))}
+      </Space>
+
+      <Divider style={{ marginBottom: 0, marginTop: 0 }} />
+      <Flex justify="space-between" style={{ padding: "8px" }}>
+        <Button
+          size="small"
+          type="link"
+          onClick={() => {
+            if (selectedKeys.length > 0) {
+              clearFilters?.();
+            } else {
+              setSelectedKeys(
+                filters?.map((filter) => filter.value.toString() || "") || [],
+              );
+            }
+          }}
+        >
+          {selectedKeys.length ? "Clear" : "Select"} All
+        </Button>
+        <Button
+          size="small"
+          type="primary"
+          onClick={() => {
+            confirm?.();
+          }}
+        >
+          OK
+        </Button>
+      </Flex>
+    </Space.Compact>
   );
 };
 


### PR DESCRIPTION
NOTE: This is a stacked PR. Please merge #253, #254, #255 first.

When filtering a table based on tags, sometimes you want to see all tags except for one. This PR adds a button to select all tags, so that you don't have to manually click every tag. When a tag is selected, it becomes a clear selection button.

<img width="666" height="1176" alt="image" src="https://github.com/user-attachments/assets/48043c7d-b94b-4d1d-a30d-1327a243ebe4" />

<img width="544" height="1110" alt="image" src="https://github.com/user-attachments/assets/870d1a94-04ec-4c41-8e90-e8965b337a90" />
