### PR TITLE
Cleanup metrics

### DIFF
--- a/internal/database/dbcleanupservice/compact_logs.go
+++ b/internal/database/dbcleanupservice/compact_logs.go
@@ -3,7 +3,6 @@ package dbcleanupservice
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/buildbarn/bb-portal/ent/gen/ent"
 	"github.com/buildbarn/bb-portal/ent/gen/ent/bazelinvocation"
@@ -88,10 +87,7 @@ func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation 
 
 // CompactLogs compacts incomplete build logs by merging log entries for
 // the same invocation.
-func (dc *DbCleanupService) CompactLogs(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.CompactLogs")
-	defer span.End()
-
+func (dc *DbCleanupService) CompactLogs(ctx context.Context) (int64, error) {
 	invocations, err := dc.db.Ent().BazelInvocation.Query().
 		Where(
 			bazelinvocation.BepCompleted(true),
@@ -102,9 +98,7 @@ func (dc *DbCleanupService) CompactLogs(ctx context.Context) error {
 		).
 		All(ctx)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "Failed to query invocations with incomplete build logs")
-		return util.StatusWrap(err, "Failed to query invocations with incomplete build logs")
+		return 0, util.StatusWrap(err, "Failed to query invocations with incomplete build logs")
 	}
 
 	errs := make([]error, 0, len(invocations))
@@ -115,17 +109,11 @@ func (dc *DbCleanupService) CompactLogs(ctx context.Context) error {
 		}
 	}
 
-	span.SetAttributes(
-		attribute.Int("invocations.total", len(invocations)),
-		attribute.Int("invocations.succeeded", len(invocations)-len(errs)),
-	)
-
+	succeeded := int64(len(invocations) - len(errs))
 	if len(errs) != 0 {
 		err = util.StatusFromMultiple(errs)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, fmt.Sprintf("%d/%d invocation logs could not be compacted", len(errs), len(invocations)))
-		return err
+		return succeeded, err
 	}
 
-	return nil
+	return succeeded, nil
 }

--- a/internal/database/dbcleanupservice/dbcleanupservice.go
+++ b/internal/database/dbcleanupservice/dbcleanupservice.go
@@ -2,6 +2,7 @@ package dbcleanupservice
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math/rand/v2"
 	"time"
@@ -9,11 +10,13 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/build"
 	"github.com/buildbarn/bb-portal/internal/database"
 	"github.com/buildbarn/bb-portal/internal/database/dbauthservice"
+	prometheusmetrics "github.com/buildbarn/bb-portal/pkg/prometheus_metrics"
 	"github.com/buildbarn/bb-portal/pkg/proto/configuration/bb_portal"
 	"github.com/buildbarn/bb-storage/pkg/clock"
 	"github.com/buildbarn/bb-storage/pkg/program"
 	"github.com/buildbarn/bb-storage/pkg/util"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -86,34 +89,34 @@ func (dc *DbCleanupService) StartDbCleanupService(ctx context.Context, group pro
 			case <-ctx.Done():
 				return nil
 			case <-time.After(timeToSleep):
-				if err := dc.LockInvocationsWithNoRecentEvents(ctx); err != nil {
+				if err := dc.executeTask(ctx, "LockInvocationsWithNoRecentEvents", "invocations_locked", dc.LockInvocationsWithNoRecentEvents); err != nil {
 					slog.Warn("Failed to lock unfinished invocations with no recent events", "err", err)
 				}
-				if err := dc.UpdateInvocationEndedAtFromEvents(ctx); err != nil {
+				if err := dc.executeTask(ctx, "UpdateInvocationEndedAtFromEvents", "updated_invocations", dc.UpdateInvocationEndedAtFromEvents); err != nil {
 					slog.Warn("Failed to update invocation ended_at from event metadata", "err", err)
 				}
-				if err := dc.CompactLogs(ctx); err != nil {
+				if err := dc.executeTask(ctx, "CompactLogs", "compacted_logs", dc.CompactLogs); err != nil {
 					slog.Warn("Failed to compact logs", "err", err)
 				}
-				if err := dc.DeleteIncompleteLogs(ctx); err != nil {
+				if err := dc.executeTask(ctx, "DeleteIncompleteLogs", "deleted_logs", dc.DeleteIncompleteLogs); err != nil {
 					slog.Warn("Failed to delete incomplete logs", "err", err)
 				}
-				if err := dc.RemoveOldInvocations(ctx); err != nil {
+				if err := dc.executeTask(ctx, "RemoveOldInvocations", "deleted_invocations", dc.RemoveOldInvocations); err != nil {
 					slog.Warn("Failed to remove old invocations", "err", err)
 				}
-				if err := dc.RemoveInactiveUsers(ctx); err != nil {
+				if err := dc.executeTask(ctx, "RemoveInactiveUsers", "deleted_users", dc.RemoveInactiveUsers); err != nil {
 					slog.Warn("Failed to remove users without invocations")
 				}
-				if err := dc.RemoveBuildsWithoutInvocations(ctx); err != nil {
+				if err := dc.executeTask(ctx, "RemoveBuildsWithoutInvocations", "deleted_builds", dc.RemoveBuildsWithoutInvocations); err != nil {
 					slog.Warn("Failed to remove builds without invocations", "err", err)
 				}
-				if err := dc.RemoveTargetKindMappings(ctx); err != nil {
+				if err := dc.executeTask(ctx, "RemoveTargetKindMappings", "removed_target_kind_mappings", dc.RemoveTargetKindMappings); err != nil {
 					slog.Warn("Failed to remove old TargetKindMappings", "err", err)
 				}
-				if err := dc.RemoveUnusedTargets(ctx); err != nil {
+				if err := dc.executeTask(ctx, "RemoveUnusedTargets", "removed_unused_targets", dc.RemoveUnusedTargets); err != nil {
 					slog.Warn("Failed to remove unused targets", "err", err)
 				}
-				if err := dc.RemoveOrphanedTestTargets(ctx); err != nil {
+				if err := dc.executeTask(ctx, "RemoveOrphanedTestTargets", "removed_test_targets", dc.RemoveOrphanedTestTargets); err != nil {
 					slog.Warn("Failed to remove orphaned test targets", "err", err)
 				}
 			}
@@ -123,20 +126,35 @@ func (dc *DbCleanupService) StartDbCleanupService(ctx context.Context, group pro
 
 // RemoveBuildsWithoutInvocations removes builds that do not have any
 // associated invocations.
-func (dc *DbCleanupService) RemoveBuildsWithoutInvocations(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.RemoveBuildsWithoutInvocations")
-	defer span.End()
-
+func (dc *DbCleanupService) RemoveBuildsWithoutInvocations(ctx context.Context) (int64, error) {
 	deletedBuilds, err := dc.db.Ent().Build.Delete().
 		Where(
 			build.Not(build.HasInvocations()),
 		).
 		Exec(ctx)
 	if err != nil {
-		return util.StatusWrap(err, "Failed to remove builds without invocations")
+		return 0, util.StatusWrap(err, "Failed to remove builds without invocations")
 	}
 
-	span.SetAttributes(attribute.KeyValue{Key: "deleted_builds", Value: attribute.IntValue(deletedBuilds)})
+	return int64(deletedBuilds), nil
+}
 
-	return nil
+// A helper function which records metrics and tracing attributes
+// for the cleanup tasks
+func (dc *DbCleanupService) executeTask(ctx context.Context, taskName, attributeKey string, task func(context.Context) (int64, error)) error {
+	ctx, span := dc.tracer.Start(ctx, fmt.Sprintf("DbCleanupService.%s", taskName))
+	defer span.End()
+	start := dc.clock.Now()
+
+	volume, err := task(ctx)
+	prometheusmetrics.CleanupDurations.WithLabelValues(taskName).Add(dc.clock.Now().Sub(start).Seconds())
+	prometheusmetrics.CleanupVolumes.WithLabelValues(taskName).Add(float64(volume))
+	span.SetAttributes(attribute.Int64(attributeKey, volume))
+
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, fmt.Sprintf("An error occured during cleanup service %s", taskName))
+	}
+
+	return err
 }

--- a/internal/database/dbcleanupservice/dbcleanupservice_test.go
+++ b/internal/database/dbcleanupservice/dbcleanupservice_test.go
@@ -98,8 +98,9 @@ func TestCompactLogs(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.CompactLogs(ctx)
+		compacted, err := cleanup.CompactLogs(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, compacted)
 		count, err := client.BuildLogChunk.Query().Where(
 			buildlogchunk.HasBazelInvocationWith(
 				bazelinvocation.ID(inv.ID),
@@ -137,12 +138,14 @@ func TestCompactLogs(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		// Delete attempt before compaction should not delete logs.
-		err = cleanup.DeleteIncompleteLogs(ctx)
+		deleted, err := cleanup.DeleteIncompleteLogs(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 		requireIncompleteLogCount(t, client, 6)
 		// Compaction should not delete logs
-		err = cleanup.CompactLogs(ctx)
+		compacted, err := cleanup.CompactLogs(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, compacted)
 		requireIncompleteLogCount(t, client, 6)
 		chunk, err := client.BuildLogChunk.Query().Where(
 			buildlogchunk.HasBazelInvocationWith(
@@ -156,8 +159,9 @@ func TestCompactLogs(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "\x1b[35mWARNING: \x1b[0mBuild options --dynamic_mode, --extra_execution_platforms, and --extra_toolchains have changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).\n\x1b[32mINFO: \x1b[0mAnalyzed target //:hello (0 packages loaded, 2 targets configured).\n\x1b[32mINFO: \x1b[0mFound 1 target...\nTarget //:hello up-to-date:\n  bazel-bin/hello.sh\n\x1b[32mINFO: \x1b[0mElapsed time: 0.137s, Critical Path: 0.02s\n\x1b[32mINFO: \x1b[0m2 processes: 1 internal, 1 linux-sandbox.\n\x1b[32mINFO: \x1b[0mBuild completed successfully, 2 total actions\n\x1b[32mINFO:\x1b[0m \n", string(data))
 		// Now logs should be deleted
-		err = cleanup.DeleteIncompleteLogs(ctx)
+		deleted, err = cleanup.DeleteIncompleteLogs(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 6, deleted)
 		requireIncompleteLogCount(t, client, 0)
 	})
 
@@ -174,11 +178,13 @@ func TestCompactLogs(t *testing.T) {
 		requireIncompleteLogCount(t, client, 6)
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.CompactLogs(ctx)
+		compacted, err := cleanup.CompactLogs(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, compacted)
 		requireIncompleteLogCount(t, client, 6)
-		err = cleanup.DeleteIncompleteLogs(ctx)
+		deleted, err := cleanup.DeleteIncompleteLogs(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 		requireIncompleteLogCount(t, client, 6)
 	})
 }
@@ -195,8 +201,9 @@ func TestRemoveBuildsWithoutInvocations(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveBuildsWithoutInvocations(ctx)
+		deleted, err := cleanup.RemoveBuildsWithoutInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.Build.Query().Count(ctx)
 		require.NoError(t, err)
@@ -217,8 +224,9 @@ func TestRemoveBuildsWithoutInvocations(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveBuildsWithoutInvocations(ctx)
+		deleted, err := cleanup.RemoveBuildsWithoutInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.Build.Query().Count(ctx)
 		require.NoError(t, err)
@@ -235,8 +243,9 @@ func TestRemoveBuildsWithoutInvocations(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveBuildsWithoutInvocations(ctx)
+		deleted, err := cleanup.RemoveBuildsWithoutInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err := client.Build.Query().Count(ctx)
 		require.NoError(t, err)
@@ -264,8 +273,9 @@ func TestRemoveBuildsWithoutInvocations(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveBuildsWithoutInvocations(ctx)
+		deleted, err := cleanup.RemoveBuildsWithoutInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 2, deleted)
 
 		count, err := client.Build.Query().Count(ctx)
 		require.NoError(t, err)

--- a/internal/database/dbcleanupservice/delete_incomplete_logs.go
+++ b/internal/database/dbcleanupservice/delete_incomplete_logs.go
@@ -6,18 +6,14 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/incompletebuildlog"
 	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // DeleteIncompleteLogs deletes logs which have had their incomplete
 // build logs normalized.
-func (dc *DbCleanupService) DeleteIncompleteLogs(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.DeleteIncompleteLogs")
-	defer span.End()
-
+func (dc *DbCleanupService) DeleteIncompleteLogs(ctx context.Context) (int64, error) {
 	start, count, err := dc.nextSlice(ctx, incompletebuildlog.Table)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	deleted, err := dc.db.Sqlc().DeleteIncompleteLogsFromPages(ctx, sqlc.DeleteIncompleteLogsFromPagesParams{
@@ -25,10 +21,8 @@ func (dc *DbCleanupService) DeleteIncompleteLogs(ctx context.Context) error {
 		Pages:    count,
 	})
 	if err != nil {
-		return util.StatusWrap(err, "Could not delete incompleted build logs")
+		return 0, util.StatusWrap(err, "Could not delete incompleted build logs")
 	}
 
-	span.SetAttributes(attribute.Int64("deleted_invocations", deleted))
-
-	return nil
+	return deleted, nil
 }

--- a/internal/database/dbcleanupservice/lockinvocations.go
+++ b/internal/database/dbcleanupservice/lockinvocations.go
@@ -6,19 +6,15 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/bazelinvocation"
 	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // LockInvocationsWithNoRecentEvents locks invocations that have not received any new
 // events in a certain period of time.
-func (dc *DbCleanupService) LockInvocationsWithNoRecentEvents(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.LockInvocationsWithNoRecentEvents")
-	defer span.End()
-
+func (dc *DbCleanupService) LockInvocationsWithNoRecentEvents(ctx context.Context) (int64, error) {
 	cutoffTime := dc.clock.Now().UTC().Add(-dc.invocationMessageTimeout)
 	start, count, err := dc.nextSlice(ctx, bazelinvocation.Table)
 	if err != nil || count == 0 {
-		return err
+		return 0, err
 	}
 
 	updatedRows, err := dc.db.Sqlc().LockStaleInvocationsFromPages(
@@ -30,26 +26,19 @@ func (dc *DbCleanupService) LockInvocationsWithNoRecentEvents(ctx context.Contex
 		},
 	)
 	if err != nil {
-		return util.StatusWrap(err, "Failed to lock invocations")
+		return 0, util.StatusWrap(err, "Failed to lock invocations")
 	}
 
-	span.SetAttributes(attribute.Int64("invocations_locked", updatedRows))
-
-	return nil
+	return updatedRows, nil
 }
 
 // UpdateInvocationEndedAtFromEvents updates the ended_at timestamp of locked
 // invocations based on the latest event metadata.
-func (dc *DbCleanupService) UpdateInvocationEndedAtFromEvents(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.UpdateInvocationEndedAtFromEvents")
-	defer span.End()
-
+func (dc *DbCleanupService) UpdateInvocationEndedAtFromEvents(ctx context.Context) (int64, error) {
 	updatedRows, err := dc.db.Sqlc().UpdateCompletedInvocationWithEndTimeFromEventMetadata(ctx)
 	if err != nil {
-		return util.StatusWrap(err, "Failed to update invocation ended_at from event metadata")
+		return 0, util.StatusWrap(err, "Failed to update invocation ended_at from event metadata")
 	}
 
-	span.SetAttributes(attribute.KeyValue{Key: "invocations_updated", Value: attribute.Int64Value(updatedRows)})
-
-	return nil
+	return updatedRows, nil
 }

--- a/internal/database/dbcleanupservice/lockinvocations_test.go
+++ b/internal/database/dbcleanupservice/lockinvocations_test.go
@@ -28,8 +28,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 	})
 
 	t.Run("UnfinishedInvocation-NoEventMetadata", func(t *testing.T) {
@@ -42,8 +43,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		resInv, err := client.BazelInvocation.Get(ctx, startInv.ID)
 		require.NoError(t, err)
@@ -64,8 +66,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		resInv, err := client.BazelInvocation.Get(ctx, startInv.ID)
 		require.NoError(t, err)
@@ -90,8 +93,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, invocationDb.ID)
 		require.NoError(t, err)
@@ -117,8 +121,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, invocationDb.ID)
 		require.NoError(t, err)
@@ -142,8 +147,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, invocationDb.ID)
 		require.NoError(t, err)
@@ -169,8 +175,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, invocationDb.ID)
 		require.NoError(t, err)
@@ -208,8 +215,9 @@ func TestLockInvocationsWithNoRecentEvents(t *testing.T) {
 		require.NoError(t, err)
 
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.LockInvocationsWithNoRecentEvents(ctx)
+		locked, err := cleanup.LockInvocationsWithNoRecentEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, locked)
 
 		gotOld, err := client.BazelInvocation.Get(ctx, invOld.ID)
 		require.NoError(t, err)
@@ -232,8 +240,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 	})
 
 	t.Run("NoEndedAt-NoEventMetadata", func(t *testing.T) {
@@ -247,8 +256,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		resInv, err := client.BazelInvocation.Get(ctx, startInv.ID)
 		require.NoError(t, err)
@@ -268,8 +278,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, startInv.ID)
 		require.NoError(t, err)
@@ -296,8 +307,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, invocationDb.ID)
 		require.NoError(t, err)
@@ -326,8 +338,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		inv, err := client.BazelInvocation.Get(ctx, invocationDb.ID)
 		require.NoError(t, err)
@@ -370,8 +383,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, locked)
 
 		gotUpdated, err := client.BazelInvocation.Get(ctx, invToUpdate.ID)
 		require.NoError(t, err)
@@ -400,8 +414,9 @@ func TestUpdateInvocationEndedAtFromEvents(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.UpdateInvocationEndedAtFromEvents(ctx)
+		locked, err := cleanup.UpdateInvocationEndedAtFromEvents(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, locked)
 
 		gotNotUpdated, err := client.BazelInvocation.Get(ctx, invToNotUpdate.ID)
 		require.NoError(t, err)

--- a/internal/database/dbcleanupservice/remove_old_invocations.go
+++ b/internal/database/dbcleanupservice/remove_old_invocations.go
@@ -7,19 +7,15 @@ import (
 	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	prometheusmetrics "github.com/buildbarn/bb-portal/pkg/prometheus_metrics"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // RemoveOldInvocations removes invocations that have completed before a
 // certain cutoff time.
-func (dc *DbCleanupService) RemoveOldInvocations(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.RemoveOldInvocations")
-	defer span.End()
-
+func (dc *DbCleanupService) RemoveOldInvocations(ctx context.Context) (int64, error) {
 	cutoffTime := dc.clock.Now().UTC().Add(-dc.invocationRetention)
 	start, count, err := dc.nextSlice(ctx, bazelinvocation.Table)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	deleted, err := dc.db.Sqlc().DeleteOldInvocationsFromPages(ctx, sqlc.DeleteOldInvocationsFromPagesParams{
@@ -28,10 +24,9 @@ func (dc *DbCleanupService) RemoveOldInvocations(ctx context.Context) error {
 		CutoffTime: cutoffTime,
 	})
 	if err != nil {
-		return util.StatusWrap(err, "Failed to remove old invocations")
+		return 0, util.StatusWrap(err, "Failed to remove old invocations")
 	}
 
-	span.SetAttributes(attribute.Int64("deleted_invocations", deleted))
 	prometheusmetrics.SyncInvocations(ctx, dc.db.Ent())
-	return nil
+	return deleted, nil
 }

--- a/internal/database/dbcleanupservice/remove_old_invocations_test.go
+++ b/internal/database/dbcleanupservice/remove_old_invocations_test.go
@@ -27,8 +27,9 @@ func TestRemoveOldInvocations(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.RemoveOldInvocations(ctx)
+		deleted, err := cleanup.RemoveOldInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.BazelInvocation.Query().Count(ctx)
 		require.NoError(t, err)
@@ -47,8 +48,9 @@ func TestRemoveOldInvocations(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.RemoveOldInvocations(ctx)
+		deleted, err := cleanup.RemoveOldInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.BazelInvocation.Query().Count(ctx)
 		require.NoError(t, err)
@@ -68,8 +70,9 @@ func TestRemoveOldInvocations(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.RemoveOldInvocations(ctx)
+		deleted, err := cleanup.RemoveOldInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.BazelInvocation.Query().Count(ctx)
 		require.NoError(t, err)
@@ -90,8 +93,9 @@ func TestRemoveOldInvocations(t *testing.T) {
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
 
-		err = cleanup.RemoveOldInvocations(ctx)
+		deleted, err := cleanup.RemoveOldInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err := client.BazelInvocation.Query().Count(ctx)
 		require.NoError(t, err)
@@ -128,8 +132,9 @@ func TestRemoveOldInvocations(t *testing.T) {
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
 		clock.EXPECT().Now().Return(cleanupTime)
-		err = cleanup.RemoveOldInvocations(ctx)
+		deleted, err := cleanup.RemoveOldInvocations(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err := client.BazelInvocation.Query().Count(ctx)
 		require.NoError(t, err)

--- a/internal/database/dbcleanupservice/remove_orphaned_test_targets.go
+++ b/internal/database/dbcleanupservice/remove_orphaned_test_targets.go
@@ -6,18 +6,14 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/testtarget"
 	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // RemoveOrphanedTestTargets remove the test target marker from targest
 // which no longer are referred to as tests by any invocation.
-func (dc *DbCleanupService) RemoveOrphanedTestTargets(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.RemoveOrphanedTestTargets")
-	defer span.End()
-
+func (dc *DbCleanupService) RemoveOrphanedTestTargets(ctx context.Context) (int64, error) {
 	start, count, err := dc.nextSlice(ctx, testtarget.Table)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	deleted, err := dc.db.Sqlc().DeleteOrphanedTestTargetsFromPages(ctx, sqlc.DeleteOrphanedTestTargetsFromPagesParams{
@@ -25,9 +21,8 @@ func (dc *DbCleanupService) RemoveOrphanedTestTargets(ctx context.Context) error
 		Pages:    count,
 	})
 	if err != nil {
-		return util.StatusWrap(err, "Failed to remove orphaned test targets")
+		return 0, util.StatusWrap(err, "Failed to remove orphaned test targets")
 	}
 
-	span.SetAttributes(attribute.Int64("deleted_test_targets", deleted))
-	return nil
+	return deleted, nil
 }

--- a/internal/database/dbcleanupservice/remove_orphaned_test_targets_test.go
+++ b/internal/database/dbcleanupservice/remove_orphaned_test_targets_test.go
@@ -48,8 +48,9 @@ func TestDbCleanupService_RemoveOrphanedTestTargets(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, count, "Both TestTargets should exist before cleanup")
 
-	err = cleanupService.RemoveOrphanedTestTargets(ctx)
+	deleted, err := cleanupService.RemoveOrphanedTestTargets(ctx)
 	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
 
 	remainingCount, err := db.Ent().TestTarget.Query().Count(ctx)
 	require.NoError(t, err)

--- a/internal/database/dbcleanupservice/remove_target_kind_mappings.go
+++ b/internal/database/dbcleanupservice/remove_target_kind_mappings.go
@@ -6,18 +6,14 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/targetkindmapping"
 	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // RemoveTargetKindMappings removes TargetKindMappings for BazelInvocations
 // that are completed.
-func (dc *DbCleanupService) RemoveTargetKindMappings(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.RemoveTargetKindMappings")
-	defer span.End()
-
+func (dc *DbCleanupService) RemoveTargetKindMappings(ctx context.Context) (int64, error) {
 	start, count, err := dc.nextSlice(ctx, targetkindmapping.Table)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	deleted, err := dc.db.Sqlc().DeleteTargetKindMappingsFromPages(ctx, sqlc.DeleteTargetKindMappingsFromPagesParams{
@@ -25,10 +21,8 @@ func (dc *DbCleanupService) RemoveTargetKindMappings(ctx context.Context) error 
 		Pages:    count,
 	})
 	if err != nil {
-		return util.StatusWrap(err, "Failed to remove old TargetKindMappings")
+		return 0, util.StatusWrap(err, "Failed to remove old TargetKindMappings")
 	}
 
-	span.SetAttributes(attribute.Int64("target_kind_mappings_removed", deleted))
-
-	return nil
+	return deleted, nil
 }

--- a/internal/database/dbcleanupservice/remove_target_kind_mappings_test.go
+++ b/internal/database/dbcleanupservice/remove_target_kind_mappings_test.go
@@ -36,8 +36,9 @@ func TestRemoveTargetKindMappings(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveTargetKindMappings(ctx)
+		val, err := cleanup.RemoveTargetKindMappings(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, val)
 
 		count, err := client.TargetKindMapping.Query().Count(ctx)
 		require.NoError(t, err)
@@ -64,8 +65,9 @@ func TestRemoveTargetKindMappings(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveTargetKindMappings(ctx)
+		val, err := cleanup.RemoveTargetKindMappings(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, val)
 
 		count, err := client.TargetKindMapping.Query().Count(ctx)
 		require.NoError(t, err)
@@ -84,8 +86,9 @@ func TestRemoveTargetKindMappings(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveTargetKindMappings(ctx)
+		deleted, err := cleanup.RemoveTargetKindMappings(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.TargetKindMapping.Query().Count(ctx)
 		require.NoError(t, err)
@@ -112,8 +115,9 @@ func TestRemoveTargetKindMappings(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveTargetKindMappings(ctx)
+		deleted, err := cleanup.RemoveTargetKindMappings(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err := client.TargetKindMapping.Query().Count(ctx)
 		require.NoError(t, err)
@@ -158,8 +162,9 @@ func TestRemoveTargetKindMappings(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveTargetKindMappings(ctx)
+		deleted, err := cleanup.RemoveTargetKindMappings(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 3, deleted)
 
 		count, err := client.TargetKindMapping.Query().Count(ctx)
 		require.NoError(t, err)

--- a/internal/database/dbcleanupservice/remove_unused_targets.go
+++ b/internal/database/dbcleanupservice/remove_unused_targets.go
@@ -6,18 +6,14 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/target"
 	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // RemoveUnusedTargets removes Targets that have no InvocationTargets or
 // TargetKindMappings.
-func (dc *DbCleanupService) RemoveUnusedTargets(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.RemoveUnusedTargets")
-	defer span.End()
-
+func (dc *DbCleanupService) RemoveUnusedTargets(ctx context.Context) (int64, error) {
 	start, count, err := dc.nextSlice(ctx, target.Table)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	deleted, err := dc.db.Sqlc().DeleteUnusedTargetsFromPages(ctx, sqlc.DeleteUnusedTargetsFromPagesParams{
@@ -25,9 +21,8 @@ func (dc *DbCleanupService) RemoveUnusedTargets(ctx context.Context) error {
 		Pages:    count,
 	})
 	if err != nil {
-		return util.StatusWrap(err, "Failed to remove unused Targets")
+		return 0, util.StatusWrap(err, "Failed to remove unused Targets")
 	}
 
-	span.SetAttributes(attribute.Int64("unused_targets_removed", deleted))
-	return nil
+	return deleted, nil
 }

--- a/internal/database/dbcleanupservice/remove_unused_targets_test.go
+++ b/internal/database/dbcleanupservice/remove_unused_targets_test.go
@@ -25,8 +25,9 @@ func TestRemoveUnusedTargets(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveUnusedTargets(ctx)
+		deleted, err := cleanup.RemoveUnusedTargets(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.Target.Query().Count(ctx)
 		require.NoError(t, err)
@@ -49,8 +50,9 @@ func TestRemoveUnusedTargets(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveUnusedTargets(ctx)
+		deleted, err := cleanup.RemoveUnusedTargets(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err := client.Target.Query().Count(ctx)
 		require.NoError(t, err)
@@ -83,8 +85,9 @@ func TestRemoveUnusedTargets(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveUnusedTargets(ctx)
+		deleted, err := cleanup.RemoveUnusedTargets(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.Target.Query().Count(ctx)
 		require.NoError(t, err)
@@ -116,8 +119,9 @@ func TestRemoveUnusedTargets(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveUnusedTargets(ctx)
+		deleted, err := cleanup.RemoveUnusedTargets(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.Target.Query().Count(ctx)
 		require.NoError(t, err)
@@ -156,8 +160,9 @@ func TestRemoveUnusedTargets(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveUnusedTargets(ctx)
+		deleted, err := cleanup.RemoveUnusedTargets(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.Target.Query().Count(ctx)
 		require.NoError(t, err)

--- a/internal/database/dbcleanupservice/removeinactiveusers.go
+++ b/internal/database/dbcleanupservice/removeinactiveusers.go
@@ -6,23 +6,18 @@ import (
 	"github.com/buildbarn/bb-portal/ent/gen/ent/authenticateduser"
 	prometheusmetrics "github.com/buildbarn/bb-portal/pkg/prometheus_metrics"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // RemoveInactiveUsers removes all users with no associated invocations.
-func (dc *DbCleanupService) RemoveInactiveUsers(ctx context.Context) error {
-	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.RemoveInactiveUsers")
-	defer span.End()
-
+func (dc *DbCleanupService) RemoveInactiveUsers(ctx context.Context) (int64, error) {
 	deletedUsers, err := dc.db.Ent().AuthenticatedUser.Delete().
 		Where(authenticateduser.Not(authenticateduser.HasBazelInvocations())).
 		Exec(ctx)
 	if err != nil {
-		return util.StatusWrap(err, "Failed to remove inactive users")
+		return 0, util.StatusWrap(err, "Failed to remove inactive users")
 	}
 
-	span.SetAttributes(attribute.KeyValue{Key: "deleted_users", Value: attribute.IntValue(deletedUsers)})
 	prometheusmetrics.SyncAuthenticatedUsersCount(ctx, dc.db.Ent())
 
-	return nil
+	return int64(deletedUsers), nil
 }

--- a/internal/database/dbcleanupservice/removeinactiveusers_test.go
+++ b/internal/database/dbcleanupservice/removeinactiveusers_test.go
@@ -26,8 +26,9 @@ func TestRemoveInactiveUser(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveInactiveUsers(ctx)
+		deleted, err := cleanup.RemoveInactiveUsers(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.AuthenticatedUser.Query().Count(ctx)
 		require.NoError(t, err)
@@ -47,8 +48,9 @@ func TestRemoveInactiveUser(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveInactiveUsers(ctx)
+		deleted, err := cleanup.RemoveInactiveUsers(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err := client.AuthenticatedUser.Query().Count(ctx)
 		require.NoError(t, err)
@@ -74,8 +76,9 @@ func TestRemoveInactiveUser(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveInactiveUsers(ctx)
+		deleted, err := cleanup.RemoveInactiveUsers(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
 
 		count, err := client.AuthenticatedUser.Query().Count(ctx)
 		require.NoError(t, err)
@@ -113,8 +116,9 @@ func TestRemoveInactiveUser(t *testing.T) {
 
 		cleanup, err := getNewDbCleanupService(db, clock, traceProvider)
 		require.NoError(t, err)
-		err = cleanup.RemoveInactiveUsers(ctx)
+		deleted, err := cleanup.RemoveInactiveUsers(ctx)
 		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted)
 
 		count, err = client.AuthenticatedUser.Query().Count(ctx)
 		require.NoError(t, err)

--- a/pkg/prometheus_metrics/metrics.go
+++ b/pkg/prometheus_metrics/metrics.go
@@ -17,30 +17,51 @@ const (
 
 	// AuthenticatedUsersLabel The label for authenticated users in Invocations
 	AuthenticatedUsersLabel = "Authenticated"
+
+	namespace = "buildbarn"
+	subsystem = "portal"
 )
 
 var (
 	// Invocations A gauge for invocations
 	Invocations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "buildbarn",
-		Subsystem: "portal",
+		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      "invocations",
 		Help:      "Number of Invocations by authentication status",
 	}, []string{"AuthStatus"})
 
 	// AuthenticatedUsersCount A gauge for the number of authenticated users
 	AuthenticatedUsersCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "buildbarn",
-		Subsystem: "portal",
+		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      "authenticated_user_count",
 		Help:      "Number of Unique Authenticated Users",
 	})
+
+	// CleanupDurations A counter for recording durations of the cleanup service
+	CleanupDurations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "cleanup_service_duration_seconds_total",
+		Help:      "Duration of each cleanup service run in seconds",
+	}, []string{"Service"})
+
+	// CleanupVolumes A counter for recording the number of entries affected by the cleanup service
+	CleanupVolumes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "cleanup_service_volume_total",
+		Help:      "Number of entries affected by each cleanup service run",
+	}, []string{"Service"})
 )
 
 // RegisterMetrics registers the metrics with Prometheus
 func init() {
 	prometheus.MustRegister(Invocations)
 	prometheus.MustRegister(AuthenticatedUsersCount)
+	prometheus.MustRegister(CleanupDurations)
+	prometheus.MustRegister(CleanupVolumes)
 }
 
 // SyncMetrics synchronizes the Prometheus service with


### PR DESCRIPTION
NOTE: This is a stacked PR. Please merge #253, #254, #255, #256, #257, #258, #259, #260 first.

Add Prometheus metrics for the cleanup service that how long each cleanup took and how many entities that were cleaned.