### PR TITLE
Fix API returning internal error on invalid routes

### DIFF
--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"reflect"
 	"time"
@@ -64,6 +65,7 @@ func main() {
 		}
 
 		router := mux.NewRouter()
+		router.NotFoundHandler = http.HandlerFunc(http.NotFound)
 		router.Use(otelmux.Middleware("bb-portal-http", otelmux.WithTracerProvider(tracerProvider)))
 
 		if err = blobstoreservice.NewBlobstoreService(


### PR DESCRIPTION
NOTE: This is a stacked PR. Please merge #253, #254, #255, #256, #257, #258, #259, #260, #261, #262, #263, #264 first.

When serving the frontend, we add a catch-all for `/api/` that returns the default 404 handler, since all valid API routes would already be matched, and we don't want to return `index.html` for API routes. The problem was that no default 404 handler was defined, so instead the API returned a internal error. This is now fixed by defining a default 404 handler.