### PR TITLE
Remove nested button links

### DIFF
--- a/frontend/src/components/LinkButton/index.tsx
+++ b/frontend/src/components/LinkButton/index.tsx
@@ -1,0 +1,18 @@
+import { createLink } from "@tanstack/react-router";
+import type { ButtonProps } from "antd";
+import { Button } from "antd";
+import * as React from "react";
+
+// Looks like and can be styles like an AntD button,
+// but behaves like a Tanstack link, including type safety and pre-fetching on hover.
+
+// TanStack Router needs the ref to manage focus and accessibility.
+const AntdButtonWrapper = React.forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  ButtonProps
+>((props, ref) => {
+  return <Button ref={ref} {...props} />;
+});
+
+// Wrap it in createLink to inject all TanStack Router functionality
+export const LinkButton = createLink(AntdButtonWrapper);

--- a/frontend/src/components/Targets/TargetGridBtn/index.tsx
+++ b/frontend/src/components/Targets/TargetGridBtn/index.tsx
@@ -3,8 +3,8 @@ import {
   CloseCircleFilled,
   QuestionCircleFilled,
 } from "@ant-design/icons";
-import { Button } from "antd";
 import type React from "react";
+import { LinkButton } from "@/components/LinkButton";
 import themeStyles from "@/theme/theme.module.css";
 
 interface Props {
@@ -33,14 +33,14 @@ function getClassForStatus(status: boolean | null) {
 }
 
 const TargetGridBtn: React.FC<Props> = ({ status, invocationId }) => {
-  const resultTag = (
-    <Button
-      href={`/bazel-invocations/${invocationId}`}
+  return (
+    <LinkButton
+      to="/bazel-invocations/$invocationID"
+      params={{ invocationID: invocationId }}
       icon={getIconForStatus(status)}
       className={getClassForStatus(status)}
     />
   );
-  return <>{resultTag}</>;
 };
 
 export default TargetGridBtn;

--- a/frontend/src/components/TestGridBtn/index.tsx
+++ b/frontend/src/components/TestGridBtn/index.tsx
@@ -6,25 +6,52 @@ import {
   QuestionCircleFilled,
   StopOutlined,
 } from "@ant-design/icons";
-import { Link } from "@tanstack/react-router";
-import { Button } from "antd";
+import type { ButtonColorType } from "antd/es/button";
 import type React from "react";
+import { LinkButton } from "@/components/LinkButton";
+import type { TestStatusEnum } from "@/components/TestStatusTag";
 import themeStyles from "@/theme/theme.module.css";
 
-export const ALL_STATUS_VALUES = [
-  "NO_STATUS",
-  "PASSED",
-  "FLAKY",
-  "TIMEOUT",
-  "FAILED",
-  "INCOMPLETE",
-  "REMOTE_FAILURE",
-  "FAILED_TO_BUILD",
-  "TOOL_HALTED_BEFORE_TESTING",
-] as const;
-
-export type StatusTuple = typeof ALL_STATUS_VALUES;
-export type TestStatusEnum = StatusTuple[number];
+const STATUS_CONFIG: Record<
+  TestStatusEnum,
+  {
+    icon: React.ReactNode;
+    className: string;
+    color?: ButtonColorType;
+  }
+> = {
+  NO_STATUS: {
+    icon: <QuestionCircleFilled />,
+    className: themeStyles.colorDisabled,
+  },
+  PASSED: { icon: <CheckCircleFilled />, className: themeStyles.colorSuccess },
+  FLAKY: { icon: <InfoCircleFilled />, className: themeStyles.colorAborted },
+  FAILED: {
+    icon: <CloseCircleFilled />,
+    className: themeStyles.colorFailure,
+    color: "danger",
+  },
+  TIMEOUT: {
+    icon: <MinusCircleFilled />,
+    className: themeStyles.colorFailure,
+    color: "danger",
+  },
+  INCOMPLETE: { icon: <StopOutlined />, className: themeStyles.colorAborted },
+  REMOTE_FAILURE: {
+    icon: <CloseCircleFilled />,
+    className: themeStyles.colorFailure,
+    color: "danger",
+  },
+  FAILED_TO_BUILD: {
+    icon: <QuestionCircleFilled />,
+    className: themeStyles.colorFailure,
+    color: "danger",
+  },
+  TOOL_HALTED_BEFORE_TESTING: {
+    icon: <QuestionCircleFilled />,
+    className: themeStyles.colorDisabled,
+  },
+};
 
 interface Props {
   status: TestStatusEnum;
@@ -32,72 +59,16 @@ interface Props {
 }
 
 const TestGridBtn: React.FC<Props> = ({ status, invocationId }) => {
-  const ICON_BTNS: { [key in TestStatusEnum]: React.ReactNode } = {
-    NO_STATUS: (
-      <Button
-        icon={<QuestionCircleFilled />}
-        className={themeStyles.colorDisabled}
-      />
-    ),
-    PASSED: (
-      <Button
-        icon={<CheckCircleFilled />}
-        className={themeStyles.colorSuccess}
-      />
-    ),
-    FLAKY: (
-      <Button
-        icon={<InfoCircleFilled />}
-        className={themeStyles.colorAborted}
-      />
-    ),
-    FAILED: (
-      <Button
-        icon={<CloseCircleFilled />}
-        color="danger"
-        className={themeStyles.colorFailure}
-      />
-    ),
-    TIMEOUT: (
-      <Button
-        icon={<MinusCircleFilled />}
-        color="danger"
-        className={themeStyles.colorFailure}
-      />
-    ),
-    INCOMPLETE: (
-      <Button icon={<StopOutlined />} className={themeStyles.colorAborted} />
-    ),
-    REMOTE_FAILURE: (
-      <Button
-        icon={<CloseCircleFilled />}
-        color="danger"
-        className={themeStyles.colorFailure}
-      />
-    ),
-    FAILED_TO_BUILD: (
-      <Button
-        icon={<QuestionCircleFilled />}
-        color="danger"
-        className={themeStyles.colorFailure}
-      />
-    ),
-    TOOL_HALTED_BEFORE_TESTING: (
-      <Button
-        icon={<QuestionCircleFilled />}
-        className={themeStyles.colorDisabled}
-      />
-    ),
-  };
+  const config = STATUS_CONFIG[status] || STATUS_CONFIG.NO_STATUS;
 
-  const resultTag = ICON_BTNS[status] || ICON_BTNS.NO_STATUS;
   return (
-    <Link
+    <LinkButton
       to="/bazel-invocations/$invocationID"
       params={{ invocationID: invocationId }}
-    >
-      {resultTag}
-    </Link>
+      icon={config.icon}
+      className={config.className}
+      color={config.color}
+    />
   );
 };
 


### PR DESCRIPTION
Instead of nesting a button inside of a link to get the styling of a button but with the routeing of the Tanstack link, we create a single component for that purpose, using the approach recommended by Tanstack router (https://tanstack.com/router/v1/docs/guide/custom-link).