### PR TITLE
bb_portal: make bb_portal importable as a module dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,12 +79,12 @@ single_version_override(
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.from_file(go_mod = "//:go.mod")
 
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
-go_deps.gazelle_override(
+go_deps_dev = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+go_deps_dev.gazelle_override(
     build_file_generation = "on",
     path = "github.com/cncf/xds/go",
 )
-go_deps.module_override(
+go_deps_dev.module_override(
     patches = [
         "@com_github_buildbarn_bb_remote_execution//:patches/com_github_hanwen_go_fuse_v2/direntrylist-offsets-and-testability.diff",
         "@com_github_buildbarn_bb_remote_execution//:patches/com_github_hanwen_go_fuse_v2/writeback-cache.diff",
@@ -92,22 +92,24 @@ go_deps.module_override(
     ],
     path = "github.com/hanwen/go-fuse/v2",
 )
-go_deps.module_override(
+go_deps_dev.module_override(
     patches = ["@com_github_buildbarn_bb_storage//:patches/org_golang_x_sys/o-search.diff"],
     path = "golang.org/x/sys",
 )
-go_deps.module_override(
+go_deps_dev.module_override(
     patches = [
         "@com_github_buildbarn_bb_storage//:patches/org_uber_go_mock/mocks-for-funcs.diff",
     ],
     path = "go.uber.org/mock",
 )
-go_deps.module_override(
+go_deps_dev.module_override(
     patches = [
         "//:patches/com_github_bazelbuild_buildtools/buildifier-target-cfg.diff",
     ],
     path = "github.com/bazelbuild/buildtools",
 )
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,


### PR DESCRIPTION
Importing bb_portal as a module dependency from another project currently results in an error as go_deps cannot be overridden in non-root projects. We're fixing that here by making go_deps a dev_dependency, as it is typically done in most projects.