### PR TITLE
Better error messages for invocation tabs

### DIFF
--- a/frontend/src/components/BazelInvocationTabBar/index.tsx
+++ b/frontend/src/components/BazelInvocationTabBar/index.tsx
@@ -153,17 +153,28 @@ export const BazelInvocationTabBar: React.FC<Props> = ({ invocation }) => {
 
   const menuItems = useMemo(() => getMenuItems(invocation), [invocation]);
 
-  const selectedKey = useMemo(() => {
-    const lastPathSegment = pathname.split("/").pop();
+  const selectedKeys = useMemo(() => {
+    const segments = pathname.split("/").filter((str) => str !== "");
+
+    if (
+      segments.length >= 2 &&
+      segments[segments.length - 2] === "bazel-invocations" &&
+      segments[segments.length - 1] === invocation.invocationID
+    ) {
+      return ["overview"];
+    }
+
+    const lastPathSegment = segments.pop();
     const activeItem = menuItems.find((item) => item?.key === lastPathSegment);
-    return activeItem?.key?.toString() ?? "overview";
-  }, [pathname, menuItems]);
+    const key = activeItem?.key?.toString();
+    return key ? [key] : [];
+  }, [pathname, menuItems, invocation]);
 
   return (
     <Menu
       mode="horizontal"
       style={{ background: "inherit" }}
-      selectedKeys={[selectedKey]}
+      selectedKeys={selectedKeys}
       items={menuItems}
     />
   );

--- a/frontend/src/components/InvocationTagTab/index.tsx
+++ b/frontend/src/components/InvocationTagTab/index.tsx
@@ -2,7 +2,6 @@ import { TagsOutlined } from "@ant-design/icons";
 import { Descriptions } from "antd";
 import type React from "react";
 import type { BazelInvocationTagsFragment } from "@/graphql/__generated__/graphql";
-import PortalAlert from "../PortalAlert";
 import PortalCard from "../PortalCard";
 
 const linkRegex =
@@ -13,11 +12,13 @@ interface Props {
 }
 
 export const InvocationTagTab: React.FC<Props> = ({ tags }) => {
-  const renderTags = () => {
-    if (tags.length === 0) {
-      return <PortalAlert showIcon message="This invocation has no tags." />;
-    }
-    return (
+  return (
+    <PortalCard
+      type="inner"
+      icon={<TagsOutlined />}
+      titleBits={[<span key="title">Tags</span>]}
+      style={{ width: "100%" }}
+    >
       <Descriptions bordered column={1} style={{ width: "max-content" }}>
         {tags?.map((tag) => (
           <Descriptions.Item key={tag.key} label={tag.key}>
@@ -29,17 +30,6 @@ export const InvocationTagTab: React.FC<Props> = ({ tags }) => {
           </Descriptions.Item>
         ))}
       </Descriptions>
-    );
-  };
-
-  return (
-    <PortalCard
-      type="inner"
-      icon={<TagsOutlined />}
-      titleBits={[<span key="title">Tags</span>]}
-      style={{ width: "100%" }}
-    >
-      {renderTags()}
     </PortalCard>
   );
 };

--- a/frontend/src/components/pages/BuildDetails/index.tsx
+++ b/frontend/src/components/pages/BuildDetails/index.tsx
@@ -166,7 +166,7 @@ export const BuildDetailsPage: React.FC<Props> = ({ buildUUID }) => {
               )}
               <Typography.Paragraph>
                 It could be that the build is too old and has been removed, or
-                that you don&quot;t have access to this build.
+                that you don't have access to this build.
               </Typography.Paragraph>
             </>
           }

--- a/frontend/src/components/pages/InvocationDataNotFoundAlert/index.tsx
+++ b/frontend/src/components/pages/InvocationDataNotFoundAlert/index.tsx
@@ -1,0 +1,15 @@
+import type React from "react";
+import PortalAlert from "@/components/PortalAlert";
+
+interface Props {
+  type: string;
+}
+
+export const InvocationDataNotFoundAlert: React.FC<Props> = ({ type }) => {
+  return (
+    <PortalAlert
+      showIcon
+      message={`This invocation has not reported any ${type} yet.`}
+    />
+  );
+};

--- a/frontend/src/routes/bazel-invocations.$invocationID/actions.tsx
+++ b/frontend/src/routes/bazel-invocations.$invocationID/actions.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { ActionsTab } from "@/components/ActionsTab";
 import { apolloClient } from "@/components/ApolloWrapper";
+import { InvocationDataNotFoundAlert } from "@/components/pages/InvocationDataNotFoundAlert";
 import { getFragmentData, gql } from "@/graphql/__generated__";
 import { generatePageTitle } from "@/utils/generatePageTitle";
 
@@ -63,15 +64,18 @@ export const Route = createFileRoute(
       throw notFound();
     }
 
+    const instanceName = data.getBazelInvocation.instanceName.name;
+
     if (!data.getBazelInvocation.actions) {
-      throw notFound();
+      return { instanceName, actions: undefined };
     }
 
     const actions = getFragmentData(
       BAZEL_INVOCATION_ACTIONS_FRAGMENT,
       data.getBazelInvocation?.actions,
     );
-    return { instanceName: data.getBazelInvocation.instanceName.name, actions };
+
+    return { instanceName, actions };
   },
   head: (_ctx) => ({
     meta: [
@@ -88,6 +92,11 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const { instanceName, actions } = Route.useLoaderData();
+
+  if (actions === undefined || actions.length === 0) {
+    return <InvocationDataNotFoundAlert type="actions" />;
+  }
+
   // TODO (isakstenstrom): Maybe we should fetch the logs here instead?
   return <ActionsTab instanceName={instanceName} actions={actions} />;
 }

--- a/frontend/src/routes/bazel-invocations.$invocationID/metrics.tsx
+++ b/frontend/src/routes/bazel-invocations.$invocationID/metrics.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { apolloClient } from "@/components/ApolloWrapper";
 import { BazelInvocationMetrics } from "@/components/pages/BazelInvocationMetrics";
+import { InvocationDataNotFoundAlert } from "@/components/pages/InvocationDataNotFoundAlert";
 import { getFragmentData, gql } from "@/graphql/__generated__";
 import { generatePageTitle } from "@/utils/generatePageTitle";
 
@@ -149,7 +150,7 @@ export const Route = createFileRoute(
     });
 
     if (!data?.getBazelInvocation?.metrics) {
-      throw notFound();
+      return { metrics: undefined };
     }
 
     const metrics = getFragmentData(
@@ -174,5 +175,10 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const { metrics } = Route.useLoaderData();
+
+  if (metrics === undefined) {
+    return <InvocationDataNotFoundAlert type="metrics" />;
+  }
+
   return <BazelInvocationMetrics metrics={metrics} />;
 }

--- a/frontend/src/routes/bazel-invocations.$invocationID/source-control.tsx
+++ b/frontend/src/routes/bazel-invocations.$invocationID/source-control.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { apolloClient } from "@/components/ApolloWrapper";
+import { InvocationDataNotFoundAlert } from "@/components/pages/InvocationDataNotFoundAlert";
 import SourceControlDisplay from "@/components/SourceControlDisplay";
 import { getFragmentData, gql } from "@/graphql/__generated__";
 import { generatePageTitle } from "@/utils/generatePageTitle";
@@ -39,7 +40,7 @@ export const Route = createFileRoute(
     });
 
     if (!data?.getBazelInvocation?.sourceControl) {
-      throw notFound();
+      return { sourceControl: undefined };
     }
 
     const sourceControl = getFragmentData(
@@ -63,5 +64,10 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const { sourceControl } = Route.useLoaderData();
+
+  if (sourceControl === undefined || sourceControl.length === 0) {
+    return <InvocationDataNotFoundAlert type="source control data" />;
+  }
+
   return <SourceControlDisplay sourceControl={sourceControl} />;
 }

--- a/frontend/src/routes/bazel-invocations.$invocationID/tags.tsx
+++ b/frontend/src/routes/bazel-invocations.$invocationID/tags.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { apolloClient } from "@/components/ApolloWrapper";
 import { InvocationTagTab } from "@/components/InvocationTagTab";
+import { InvocationDataNotFoundAlert } from "@/components/pages/InvocationDataNotFoundAlert";
 import { gql } from "@/graphql/__generated__";
 import { generatePageTitle } from "@/utils/generatePageTitle";
 import { parseGraphqlEdgeListWithFragment } from "@/utils/parseGraphqlEdgeList";
@@ -38,7 +39,7 @@ export const Route = createFileRoute("/bazel-invocations/$invocationID/tags")({
     });
 
     if (!data?.getBazelInvocation?.tags) {
-      throw notFound();
+      return { tags: undefined };
     }
 
     const tags = parseGraphqlEdgeListWithFragment(
@@ -62,5 +63,10 @@ export const Route = createFileRoute("/bazel-invocations/$invocationID/tags")({
 
 function RouteComponent() {
   const { tags } = Route.useLoaderData();
+
+  if (tags === undefined || tags.length === 0) {
+    return <InvocationDataNotFoundAlert type="tags" />;
+  }
+
   return <InvocationTagTab tags={tags} />;
 }


### PR DESCRIPTION
Add better error messages for invocation tabs that has no data, instead of showing a `page not found`, or a empty table.