### PR TITLE
Fix crash when viewing some test statuses

### DIFF
--- a/frontend/src/components/TestGrid/index.tsx
+++ b/frontend/src/components/TestGrid/index.tsx
@@ -11,15 +11,8 @@ import { CursorTable, getNewPaginationVariables } from "../CursorTable";
 import type { PaginationVariables } from "../CursorTable/types";
 import PortalAlert from "../PortalAlert";
 import TestGridRow from "../TestGridRow";
-import type { TestStatusEnum } from "../TestStatusTag";
 import { columns, type TestGridRowDataType } from "./columns";
 import { GET_TESTS } from "./graphql";
-
-export interface TestStatusType {
-  label: string;
-  invocationId: string;
-  status: TestStatusEnum;
-}
 
 const TestGrid: React.FC = () => {
   const [paginationVariables, setPaginationVariables] =

--- a/frontend/src/components/TestGridBtn/index.tsx
+++ b/frontend/src/components/TestGridBtn/index.tsx
@@ -6,20 +6,16 @@ import {
   QuestionCircleFilled,
   StopOutlined,
 } from "@ant-design/icons";
-import type { ButtonColorType } from "antd/es/button";
+import type { ButtonProps } from "antd/es/button";
 import type React from "react";
 import { LinkButton } from "@/components/LinkButton";
-import type { TestStatusEnum } from "@/components/TestStatusTag";
 import themeStyles from "@/theme/theme.module.css";
+import {
+  type TestStatusEnum,
+  testStatusEnumFromString,
+} from "@/types/TestStatus";
 
-const STATUS_CONFIG: Record<
-  TestStatusEnum,
-  {
-    icon: React.ReactNode;
-    className: string;
-    color?: ButtonColorType;
-  }
-> = {
+const STATUS_CONFIG: Record<TestStatusEnum, ButtonProps> = {
   NO_STATUS: {
     icon: <QuestionCircleFilled />,
     className: themeStyles.colorDisabled,
@@ -51,23 +47,24 @@ const STATUS_CONFIG: Record<
     icon: <QuestionCircleFilled />,
     className: themeStyles.colorDisabled,
   },
+  UNKNOWN: {
+    icon: <QuestionCircleFilled />,
+    className: themeStyles.colorDisabled,
+  },
 };
 
 interface Props {
-  status: TestStatusEnum;
+  status: string | null | undefined;
   invocationId: string;
 }
 
 const TestGridBtn: React.FC<Props> = ({ status, invocationId }) => {
-  const config = STATUS_CONFIG[status] || STATUS_CONFIG.NO_STATUS;
-
+  const config = STATUS_CONFIG[testStatusEnumFromString(status)];
   return (
     <LinkButton
       to="/bazel-invocations/$invocationID"
       params={{ invocationID: invocationId }}
-      icon={config.icon}
-      className={config.className}
-      color={config.color}
+      {...config}
     />
   );
 };

--- a/frontend/src/components/TestGridRow/index.tsx
+++ b/frontend/src/components/TestGridRow/index.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/graphql/__generated__/graphql";
 import { parseGraphqlEdgeList } from "@/utils/parseGraphqlEdgeList";
 import TestGridBtn from "../TestGridBtn";
-import type { TestStatusEnum } from "../TestStatusTag";
 import { GET_TESTS_FOR_TARGET } from "./graphql";
 
 interface Props {
@@ -60,7 +59,7 @@ const TestGridRow: React.FC<Props> = ({
         <TestGridBtn
           key={`test-grid-btn${item.id}`}
           invocationId={item.invocationTarget.bazelInvocation.invocationID}
-          status={item.overallStatus as TestStatusEnum}
+          status={item.overallStatus}
         />
       ))}
     </Space>

--- a/frontend/src/components/TestStatusTag/index.tsx
+++ b/frontend/src/components/TestStatusTag/index.tsx
@@ -8,32 +8,20 @@ import {
 } from "@ant-design/icons";
 import type React from "react";
 import ResultTag, { type TagVariables } from "@/components/ResultTag";
-
-export const ALL_STATUS_VALUES = [
-  "NO_STATUS",
-  "PASSED",
-  "FLAKY",
-  "TIMEOUT",
-  "FAILED",
-  "INCOMPLETE",
-  "REMOTE_FAILURE",
-  "FAILED_TO_BUILD",
-  "TOOL_HALTED_BEFORE_TESTING",
-] as const;
-
-export type StatusTuple = typeof ALL_STATUS_VALUES;
-export type TestStatusEnum = StatusTuple[number];
+import {
+  type TestStatusEnum,
+  testStatusEnumFromString,
+} from "@/types/TestStatus";
 
 interface Props {
-  status: TestStatusEnum;
-  displayText: boolean;
+  status: string | null | undefined;
 }
 
-const TEST_RESULT_TAGS: { [key in TestStatusEnum]: TagVariables } = {
+const TEST_RESULT_TAGS: Record<TestStatusEnum, TagVariables> = {
   NO_STATUS: {
     icon: <QuestionCircleFilled />,
-    text: "No Status",
     color: "default",
+    text: "No Status",
   },
   PASSED: {
     icon: <CheckCircleFilled />,
@@ -73,18 +61,16 @@ const TEST_RESULT_TAGS: { [key in TestStatusEnum]: TagVariables } = {
   TOOL_HALTED_BEFORE_TESTING: {
     icon: <QuestionCircleFilled />,
     color: "blue",
+    text: "Tool halted before testing",
+  },
+  UNKNOWN: {
+    icon: <QuestionCircleFilled />,
+    color: "default",
     text: "Status Unknown",
   },
 };
 
-const TestStatusTag: React.FC<Props> = ({ status, displayText }) => {
-  const tagVars = TEST_RESULT_TAGS[status];
-
-  if (displayText) {
-    return <ResultTag tagVars={tagVars} />;
-  }
-
-  return <ResultTag tagVars={{ ...tagVars, text: undefined }} />;
+export const TestStatusTag: React.FC<Props> = ({ status }) => {
+  const statusEnum = testStatusEnumFromString(status);
+  return <ResultTag tagVars={TEST_RESULT_TAGS[statusEnum]} />;
 };
-
-export default TestStatusTag;

--- a/frontend/src/components/TestTab/columns.tsx
+++ b/frontend/src/components/TestTab/columns.tsx
@@ -8,10 +8,11 @@ import {
   type TestSummaryOrder,
   TestSummaryOrderField,
 } from "@/graphql/__generated__/graphql";
+import { TEST_STATUS_FILTERS } from "@/types/TestStatus";
 import { readableDurationFromMilliseconds } from "@/utils/time";
 import styles from "../../theme/theme.module.css";
 import NullBooleanTag from "../NullableBooleanTag";
-import TestStatusTag, { type TestStatusEnum } from "../TestStatusTag";
+import { TestStatusTag } from "../TestStatusTag";
 
 export type TestTabRowType = NonNullable<
   NonNullable<
@@ -31,53 +32,10 @@ export const defaultSorting: TestSummaryOrder = {
 
 export const columns: TableColumnsType<TestTabRowType> = [
   {
+    key: "overallStatus",
     title: "Status",
-    dataIndex: "overallStatus",
-    render: (x) => (
-      <TestStatusTag
-        displayText={true}
-        key="status"
-        status={x as TestStatusEnum}
-      />
-    ),
-    filters: [
-      {
-        text: "No Status",
-        value: "NO_STATUS",
-      },
-      {
-        text: "Passed",
-        value: "PASSED",
-      },
-      {
-        text: "Flaky",
-        value: "FLAKY",
-      },
-      {
-        text: "Timeout",
-        value: "TIMEOUT",
-      },
-      {
-        text: "Failed",
-        value: "FAILED",
-      },
-      {
-        text: "Incomplete",
-        value: "INCOMPLETE",
-      },
-      {
-        text: "Remote Failure",
-        value: "REMOTE_FAILURE",
-      },
-      {
-        text: "Failed to Build",
-        value: "FAILED_TO_BUILD",
-      },
-      {
-        text: "Tool Halted Before Testing",
-        value: "TOOL_HALTED_BEFORE_TESTING",
-      },
-    ],
+    render: (_, record) => <TestStatusTag status={record.overallStatus} />,
+    filters: TEST_STATUS_FILTERS,
   },
   {
     title: "Label",

--- a/frontend/src/components/pages/TestDetails/columns.tsx
+++ b/frontend/src/components/pages/TestDetails/columns.tsx
@@ -4,7 +4,7 @@ import type { GetTestDetailsQuery } from "@/graphql/__generated__/graphql";
 import styles from "@/theme/theme.module.css";
 import { readableDurationFromMilliseconds } from "@/utils/time";
 import NullBooleanTag from "../../NullableBooleanTag";
-import TestStatusTag, { type TestStatusEnum } from "../../TestStatusTag";
+import { TestStatusTag } from "../../TestStatusTag";
 
 export type TestDetailsRowType = NonNullable<
   NonNullable<
@@ -17,15 +17,9 @@ export type TestDetailsRowType = NonNullable<
 
 export const columns: TableColumnsType<TestDetailsRowType> = [
   {
+    key: "status",
     title: "Status",
-    dataIndex: "status",
-    render: (_, record) => (
-      <TestStatusTag
-        displayText={true}
-        key="status"
-        status={record.overallStatus as TestStatusEnum}
-      />
-    ),
+    render: (_, record) => <TestStatusTag status={record.overallStatus} />,
   },
   {
     title: "Invocation ID",

--- a/frontend/src/types/TestStatus.ts
+++ b/frontend/src/types/TestStatus.ts
@@ -1,0 +1,64 @@
+const ALL_STATUS_VALUES = [
+  "NO_STATUS",
+  "PASSED",
+  "FLAKY",
+  "TIMEOUT",
+  "FAILED",
+  "INCOMPLETE",
+  "REMOTE_FAILURE",
+  "FAILED_TO_BUILD",
+  "TOOL_HALTED_BEFORE_TESTING",
+  "UNKNOWN",
+] as const;
+
+type StatusTuple = typeof ALL_STATUS_VALUES;
+export type TestStatusEnum = StatusTuple[number];
+
+const STATUS_SET = new Set<string>(ALL_STATUS_VALUES);
+
+export const testStatusEnumFromString = (
+  status: string | null | undefined,
+): TestStatusEnum => {
+  const isValidStatus = status && STATUS_SET.has(status);
+  return isValidStatus ? (status as TestStatusEnum) : "UNKNOWN";
+};
+
+// TODO: Add ability to filter on "UNKNOWN"
+export const TEST_STATUS_FILTERS = [
+  {
+    text: "No Status",
+    value: "NO_STATUS",
+  },
+  {
+    text: "Passed",
+    value: "PASSED",
+  },
+  {
+    text: "Flaky",
+    value: "FLAKY",
+  },
+  {
+    text: "Timeout",
+    value: "TIMEOUT",
+  },
+  {
+    text: "Failed",
+    value: "FAILED",
+  },
+  {
+    text: "Incomplete",
+    value: "INCOMPLETE",
+  },
+  {
+    text: "Remote Failure",
+    value: "REMOTE_FAILURE",
+  },
+  {
+    text: "Failed to Build",
+    value: "FAILED_TO_BUILD",
+  },
+  {
+    text: "Tool Halted Before Testing",
+    value: "TOOL_HALTED_BEFORE_TESTING",
+  },
+];


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #279 first.

Type checking was bypassed for usages of TestStatusTag, which caused a crash when the passed status was invalid. TestStatusTag has now been reworked with proper type handling.