### PR TITLE
Add zstd compression middleware to router

### DIFF
--- a/cmd/bb_portal/BUILD.bazel
+++ b/cmd/bb_portal/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//ent/gen/ent/runtime",
+        "//internal/api/http/zstdmiddleware",
         "//internal/bep",
         "//pkg/frontend",
         "//pkg/grpcweb/blobstoreservice",
@@ -18,6 +19,7 @@ go_library(
         "@com_github_buildbarn_bb_storage//pkg/http/server",
         "@com_github_buildbarn_bb_storage//pkg/program",
         "@com_github_buildbarn_bb_storage//pkg/util",
+        "@com_github_buildbarn_bb_storage//pkg/zstd",
         "@com_github_gorilla_mux//:mux",
         "@io_opentelemetry_go_contrib_instrumentation_github_com_gorilla_mux_otelmux//:otelmux",
         "@io_opentelemetry_go_otel//:otel",

--- a/cmd/bb_portal/main.go
+++ b/cmd/bb_portal/main.go
@@ -10,6 +10,7 @@ import (
 	// Needed to avoid cyclic dependencies in ent (https://entgo.io/docs/privacy#privacy-policy-registration)
 	_ "github.com/buildbarn/bb-portal/ent/gen/ent/runtime"
 
+	"github.com/buildbarn/bb-portal/internal/api/http/zstdmiddleware"
 	"github.com/buildbarn/bb-portal/internal/bep"
 	"github.com/buildbarn/bb-portal/pkg/frontend"
 	"github.com/buildbarn/bb-portal/pkg/grpcweb/blobstoreservice"
@@ -20,6 +21,7 @@ import (
 	http_server "github.com/buildbarn/bb-storage/pkg/http/server"
 	"github.com/buildbarn/bb-storage/pkg/program"
 	"github.com/buildbarn/bb-storage/pkg/util"
+	bb_zstd "github.com/buildbarn/bb-storage/pkg/zstd"
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 	"go.opentelemetry.io/otel"
@@ -64,9 +66,13 @@ func main() {
 			return util.StatusWrap(err, "Failed to create InstanceNameAuthorizer")
 		}
 
+		// Create a process-wide ZSTD compression pool.
+		zstdPool := bb_zstd.NewPoolFromConfiguration(configuration.ZstdPool)
+
 		router := mux.NewRouter()
 		router.NotFoundHandler = http.HandlerFunc(http.NotFound)
 		router.Use(otelmux.Middleware("bb-portal-http", otelmux.WithTracerProvider(tracerProvider)))
+		router.Use(zstdmiddleware.NewZstdMiddleware(zstdPool))
 
 		if err = blobstoreservice.NewBlobstoreService(
 			&configuration,
@@ -74,6 +80,7 @@ func main() {
 			dependenciesGroup,
 			grpcClientFactory,
 			instanceNameAuthorizer,
+			zstdPool,
 			router,
 		); err != nil {
 			return util.StatusWrap(err, "Failed to create Blobstore service")

--- a/internal/api/http/loghandler/log_handler.go
+++ b/internal/api/http/loghandler/log_handler.go
@@ -6,13 +6,11 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/buildbarn/bb-portal/ent/gen/ent"
 	"github.com/buildbarn/bb-portal/internal/database/dbauthservice"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/klauspost/compress/zstd"
 	grpc_codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -87,20 +85,11 @@ func (h *LogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var writer io.Writer = w
-	if strings.Contains(r.Header.Get("Accept-Encoding"), "zstd") {
-		if encoder, err := zstd.NewWriter(w); err == nil {
-			w.Header().Set("Content-Encoding", "zstd")
-			defer encoder.Close()
-			writer = encoder
-		}
-	}
-
 	// Set the header of the return result, we don't need to set the
 	// status code as that is implied to be 200 if we start writing a
 	// response.
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	if _, err := io.Copy(writer, lines); err != nil {
+	if _, err := io.Copy(w, lines); err != nil {
 		// At this point returning an error code is too late but we will
 		// mark the error in the otel metrics.
 		span.RecordError(err)

--- a/internal/api/http/zstdmiddleware/BUILD.bazel
+++ b/internal/api/http/zstdmiddleware/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "zstdmiddleware",
+    srcs = ["zstdmiddleware.go"],
+    importpath = "github.com/buildbarn/bb-portal/internal/api/http/zstdmiddleware",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/api/common",
+        "@com_github_buildbarn_bb_storage//pkg/zstd",
+    ],
+)

--- a/internal/api/http/zstdmiddleware/zstdmiddleware.go
+++ b/internal/api/http/zstdmiddleware/zstdmiddleware.go
@@ -1,0 +1,70 @@
+package zstdmiddleware
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/buildbarn/bb-portal/internal/api/common"
+	"github.com/buildbarn/bb-storage/pkg/zstd"
+)
+
+// zstdResponseWriter wraps the original ResponseWriter and redirects Writes through the zstd encoder.
+type zstdResponseWriter struct {
+	http.ResponseWriter
+	writer      io.Writer
+	wroteHeader bool
+}
+
+func (zw *zstdResponseWriter) WriteHeader(statusCode int) {
+	zw.wroteHeader = true
+
+	zw.ResponseWriter.Header().Set("Content-Encoding", "zstd")
+	zw.ResponseWriter.Header().Add("Vary", "Accept-Encoding")
+	zw.ResponseWriter.Header().Del("Content-Length")
+
+	zw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (zw *zstdResponseWriter) Write(b []byte) (int, error) {
+	// ZSTD requires modifying the headers of the response which must be
+	// done before the body is written.
+	if !zw.wroteHeader {
+		zw.WriteHeader(http.StatusOK)
+	}
+	return zw.writer.Write(b)
+}
+
+// NewZstdMiddleware returns a standard gorilla/mux compatible middleware function
+func NewZstdMiddleware(zstdPool zstd.Pool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check if client supports zstd
+			if !strings.Contains(r.Header.Get("Accept-Encoding"), "zstd") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Let Vite development websockets through unaffected
+			if r.Header.Get("Upgrade") == "websocket" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			encoder, err := zstdPool.NewEncoder(common.ExtractContextFromRequest(r), w)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			defer encoder.Close()
+
+			next.ServeHTTP(
+				&zstdResponseWriter{
+					ResponseWriter: w,
+					writer:         encoder,
+				},
+				r,
+			)
+		})
+	}
+}

--- a/internal/api/servefiles/server.go
+++ b/internal/api/servefiles/server.go
@@ -105,7 +105,6 @@ func (s FileServerService) HandleFile(w http.ResponseWriter, req *http.Request) 
 		}
 	}
 
-	w.Header().Set("Content-Length", strconv.FormatInt(digest.GetSizeBytes(), 10))
 	w.Header().Set("Content-Type", contentType)
 	w.Write(first[:n])
 	io.Copy(w, r)

--- a/pkg/frontend/BUILD.bazel
+++ b/pkg/frontend/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
         "//pkg/proto/configuration/frontend",
         "@com_github_buildbarn_bb_storage//pkg/util",
         "@com_github_gorilla_mux//:mux",
-        "@com_github_klauspost_compress//zstd",
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/pkg/frontend/embedded.go
+++ b/pkg/frontend/embedded.go
@@ -2,36 +2,17 @@ package frontend
 
 import (
 	"embed"
-	"io"
 	"io/fs"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/buildbarn/bb-portal/pkg/proto/configuration/frontend"
 	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/gorilla/mux"
-	"github.com/klauspost/compress/zstd"
 )
 
 //go:embed all:embedded_frontend
 var embeddedFiles embed.FS
-
-var zstdPool = sync.Pool{
-	New: func() any {
-		w, _ := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
-		return w
-	},
-}
-
-type compressResponseWriter struct {
-	http.ResponseWriter
-	Writer io.Writer
-}
-
-func (cw *compressResponseWriter) Write(b []byte) (int, error) {
-	return cw.Writer.Write(b)
-}
 
 func cacheControlMiddleware(sourceFS fs.FS, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,29 +30,6 @@ func cacheControlMiddleware(sourceFS fs.FS, next http.Handler) http.Handler {
 	})
 }
 
-func zstdMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.Contains(r.Header.Get("Accept-Encoding"), "zstd") {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		zw := zstdPool.Get().(*zstd.Encoder)
-		zw.Reset(w)
-		defer func() {
-			zw.Close()
-			zstdPool.Put(zw)
-		}()
-
-		w.Header().Set("Content-Encoding", "zstd")
-		w.Header().Add("Vary", "Accept-Encoding")
-		w.Header().Del("Content-Length")
-
-		crw := &compressResponseWriter{ResponseWriter: w, Writer: zw}
-		next.ServeHTTP(crw, r)
-	})
-}
-
 func setupEmbeddedHandler(router *mux.Router, frontendConfig *frontend.PortalFrontendConfiguration) error {
 	embeddedFrontendFS, err := fs.Sub(embeddedFiles, "embedded_frontend")
 	if err != nil {
@@ -85,7 +43,6 @@ func setupEmbeddedHandler(router *mux.Router, frontendConfig *frontend.PortalFro
 
 	var handler http.Handler = http.FileServerFS(spaFS)
 	handler = cacheControlMiddleware(embeddedFrontendFS, handler)
-	handler = zstdMiddleware(handler)
 
 	router.PathPrefix("/").Handler(handler)
 	return nil

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strconv"
 
 	"github.com/buildbarn/bb-portal/pkg/proto/configuration/bb_portal"
 	"github.com/buildbarn/bb-portal/pkg/proto/configuration/frontend"
@@ -106,7 +105,6 @@ func setupProxyHandler(router *mux.Router, sourceConfig *bb_portal.FrontendServi
 			}
 
 			r.Body = io.NopCloser(bytes.NewReader(newIndexContent))
-			r.Header.Set("Content-Length", strconv.Itoa(len(newIndexContent)))
 			return nil
 		},
 	}

--- a/pkg/grpcweb/blobstoreservice/blobstore_service.go
+++ b/pkg/grpcweb/blobstoreservice/blobstore_service.go
@@ -35,13 +35,11 @@ func NewBlobstoreService(
 	dependenciesGroup program.Group,
 	grpcClientFactory bb_grpc.ClientFactory,
 	instanceNameAuthorizer auth.Authorizer,
+	zstdPool bb_zstd.Pool,
 	router *mux.Router,
 ) error {
 	// Authorizer used to deny all write requests.
 	denyAuthorizer := auth.NewStaticAuthorizer(func(in digest.InstanceName) bool { return false })
-
-	// Create a process-wide ZSTD compression pool.
-	zstdPool := bb_zstd.NewPoolFromConfiguration(configuration.ZstdPool)
 
 	grpcServer := go_grpc.NewServer()
 	grpcWebServer := grpcweb.WrapServer(grpcServer)


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #282 first.

This makes so that if the browser advertises support for zstd, every response will be compressed, instead of just the frontend.