### PR TITLE
Combine cache location tags

### DIFF
--- a/frontend/src/components/CacheLocationTag/index.tsx
+++ b/frontend/src/components/CacheLocationTag/index.tsx
@@ -1,0 +1,87 @@
+import {
+  CheckCircleFilled,
+  CloseCircleFilled,
+  QuestionCircleFilled,
+} from "@ant-design/icons";
+import type React from "react";
+import ResultTag from "@/components/ResultTag";
+
+export enum CacheLocation {
+  Remote,
+  Local,
+  NotCached,
+  Unknown,
+}
+
+interface TestResultCacheLocation {
+  cachedLocally?: boolean | null | undefined;
+  cachedRemotely?: boolean | null | undefined;
+}
+
+export const cacheLocationFromTestResults = (
+  testResults: TestResultCacheLocation[] | null | undefined,
+): CacheLocation => {
+  if (!testResults || testResults.length === 0) {
+    return CacheLocation.Unknown;
+  }
+  if (testResults.every((tr) => tr.cachedRemotely === true)) {
+    return CacheLocation.Remote;
+  }
+  if (testResults.every((tr) => tr.cachedLocally === true)) {
+    return CacheLocation.Local;
+  }
+  if (testResults.some((tr) => tr.cachedLocally === false)) {
+    return CacheLocation.NotCached;
+  }
+  if (testResults.some((tr) => tr.cachedRemotely === false)) {
+    return CacheLocation.NotCached;
+  }
+  return CacheLocation.Unknown;
+};
+
+interface Props {
+  cacheLocation: CacheLocation;
+  hideText?: boolean;
+}
+
+export const CacheLocationTag: React.FC<Props> = ({
+  cacheLocation,
+  hideText,
+}) => {
+  let text: string;
+  let color: string;
+  let icon: React.ReactNode;
+
+  switch (cacheLocation) {
+    case CacheLocation.Remote:
+      color = "green";
+      text = "Remote";
+      icon = <CheckCircleFilled />;
+      break;
+    case CacheLocation.Local:
+      color = "blue";
+      text = "Local";
+      icon = <CheckCircleFilled />;
+      break;
+    case CacheLocation.NotCached:
+      color = "red";
+      text = "Not cached";
+      icon = <CloseCircleFilled />;
+      break;
+    case CacheLocation.Unknown:
+      color = "red";
+      text = "Unknown";
+      icon = <QuestionCircleFilled />;
+      break;
+  }
+
+  return (
+    <ResultTag
+      tagVars={{
+        color: color,
+        icon: icon,
+        text: hideText ? undefined : text,
+      }}
+    />
+  );
+};

--- a/frontend/src/components/TestTab/columns.tsx
+++ b/frontend/src/components/TestTab/columns.tsx
@@ -11,7 +11,7 @@ import {
 import { TEST_STATUS_FILTERS } from "@/types/TestStatus";
 import { readableDurationFromMilliseconds } from "@/utils/time";
 import styles from "../../theme/theme.module.css";
-import NullBooleanTag from "../NullableBooleanTag";
+import { type CacheLocation, CacheLocationTag } from "../CacheLocationTag";
 import { TestStatusTag } from "../TestStatusTag";
 
 export type TestTabRowType = NonNullable<
@@ -21,8 +21,7 @@ export type TestTabRowType = NonNullable<
     >[number]
   >["node"]
 > & {
-  cachedLocally: boolean | null;
-  cachedRemotely: boolean | null;
+  cacheLocation: CacheLocation;
 };
 
 export const defaultSorting: TestSummaryOrder = {
@@ -57,14 +56,11 @@ export const columns: TableColumnsType<TestTabRowType> = [
     ),
   },
   {
-    title: "Cached Locally",
-    dataIndex: "cachedLocally",
-    render: (x) => <NullBooleanTag key="local" status={x as boolean | null} />,
-  },
-  {
-    title: "Cached Remotely",
-    dataIndex: "cachedRemotely",
-    render: (x) => <NullBooleanTag key="remote" status={x as boolean | null} />,
+    key: "cacheLocation",
+    title: "Cache Location",
+    render: (_, record) => (
+      <CacheLocationTag cacheLocation={record.cacheLocation} />
+    ),
   },
   {
     title: "Duration",

--- a/frontend/src/components/TestTab/index.tsx
+++ b/frontend/src/components/TestTab/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/graphql/__generated__/graphql";
 import { parseGraphqlEdgeList } from "@/utils/parseGraphqlEdgeList";
 import styles from "../../theme/theme.module.css";
+import { cacheLocationFromTestResults } from "../CacheLocationTag";
 import { CursorTable, getNewPaginationVariables } from "../CursorTable";
 import type { PaginationVariables } from "../CursorTable/types";
 import PortalAlert from "../PortalAlert";
@@ -99,33 +100,14 @@ export const TestTab: React.FC<Props> = ({ invocationId }) => {
     }
   };
 
-  const parsedData: TestTabRowType[] = useMemo(() => {
-    return parseGraphqlEdgeList(data?.findTestSummaries).map((ts) => {
-      var cachedLocally: boolean | null = null;
-      var cachedRemotely: boolean | null = null;
-      if (
-        ts.testResults !== null &&
-        ts.testResults !== undefined &&
-        ts.testResults.length > 0
-      ) {
-        if (ts.testResults.every((tr) => tr.cachedLocally === true)) {
-          cachedLocally = true;
-        } else if (ts.testResults.some((tr) => tr.cachedLocally === false)) {
-          cachedLocally = false;
-        }
-        if (ts.testResults.every((tr) => tr.cachedRemotely === true)) {
-          cachedRemotely = true;
-        } else if (ts.testResults.some((tr) => tr.cachedRemotely === false)) {
-          cachedRemotely = false;
-        }
-      }
-      return {
+  const parsedData: TestTabRowType[] = useMemo(
+    () =>
+      parseGraphqlEdgeList(data?.findTestSummaries).map((ts) => ({
         ...ts,
-        cachedLocally: cachedLocally,
-        cachedRemotely: cachedRemotely,
-      };
-    });
-  }, [data]);
+        cacheLocation: cacheLocationFromTestResults(ts.testResults),
+      })),
+    [data],
+  );
 
   if (error) {
     return (

--- a/frontend/src/components/pages/TestDetails/columns.tsx
+++ b/frontend/src/components/pages/TestDetails/columns.tsx
@@ -1,9 +1,12 @@
 import { Link } from "@tanstack/react-router";
 import type { TableColumnsType } from "antd";
+import {
+  type CacheLocation,
+  CacheLocationTag,
+} from "@/components/CacheLocationTag";
 import type { GetTestDetailsQuery } from "@/graphql/__generated__/graphql";
 import styles from "@/theme/theme.module.css";
 import { readableDurationFromMilliseconds } from "@/utils/time";
-import NullBooleanTag from "../../NullableBooleanTag";
 import { TestStatusTag } from "../../TestStatusTag";
 
 export type TestDetailsRowType = NonNullable<
@@ -11,8 +14,7 @@ export type TestDetailsRowType = NonNullable<
     NonNullable<GetTestDetailsQuery["findTestSummaries"]["edges"]>[number]
   >["node"]
 > & {
-  cachedLocally: boolean | null;
-  cachedRemotely: boolean | null;
+  cacheLocation: CacheLocation;
 };
 
 export const columns: TableColumnsType<TestDetailsRowType> = [
@@ -36,14 +38,11 @@ export const columns: TableColumnsType<TestDetailsRowType> = [
     ),
   },
   {
-    title: "Cached Locally",
-    dataIndex: "cachedLocally",
-    render: (x) => <NullBooleanTag key="local" status={x as boolean | null} />,
-  },
-  {
-    title: "Cached Remotely",
-    dataIndex: "cachedRemotely",
-    render: (x) => <NullBooleanTag key="remote" status={x as boolean | null} />,
+    key: "cacheLocation",
+    title: "Cache Location",
+    render: (_, record) => (
+      <CacheLocationTag cacheLocation={record.cacheLocation} />
+    ),
   },
   {
     title: "Duration",

--- a/frontend/src/components/pages/TestDetails/index.tsx
+++ b/frontend/src/components/pages/TestDetails/index.tsx
@@ -14,6 +14,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { cacheLocationFromTestResults } from "@/components/CacheLocationTag";
 import type { GetTestDetailsQuery } from "@/graphql/__generated__/graphql";
 import { parseGraphqlEdgeList } from "@/utils/parseGraphqlEdgeList";
 import { CursorTable, getNewPaginationVariables } from "../../CursorTable";
@@ -57,29 +58,14 @@ export const TestDetails: React.FC<Props> = ({
     },
   );
 
-  const testSummaries: TestDetailsRowType[] = useMemo(() => {
-    return parseGraphqlEdgeList(data?.findTestSummaries).map((ts) => {
-      var cachedLocally: boolean | null = null;
-      var cachedRemotely: boolean | null = null;
-      if (ts.testResults !== null && ts.testResults !== undefined) {
-        if (ts.testResults.every((tr) => tr.cachedLocally === true)) {
-          cachedLocally = true;
-        } else if (ts.testResults.some((tr) => tr.cachedLocally === false)) {
-          cachedLocally = false;
-        }
-        if (ts.testResults.every((tr) => tr.cachedRemotely === true)) {
-          cachedRemotely = true;
-        } else if (ts.testResults.some((tr) => tr.cachedRemotely === false)) {
-          cachedRemotely = false;
-        }
-      }
-      return {
+  const testSummaries: TestDetailsRowType[] = useMemo(
+    () =>
+      parseGraphqlEdgeList(data?.findTestSummaries).map((ts) => ({
         ...ts,
-        cachedLocally: cachedLocally,
-        cachedRemotely: cachedRemotely,
-      };
-    });
-  }, [data]);
+        cacheLocation: cacheLocationFromTestResults(ts.testResults),
+      })),
+    [data],
+  );
 
   if (error) {
     return (


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #284 first.

Instead of showing two tags, one indicating locally cached and one remotely cached, we combine them into one tag showing `Locally,` `Remotely`, `Not cached`, and `Unknown`.