### PR TITLE
Potentially fix burger menu being shown incorrectly

### DIFF
--- a/frontend/src/components/PortalCard/index.tsx
+++ b/frontend/src/components/PortalCard/index.tsx
@@ -116,16 +116,18 @@ export const PortalCard: React.FC<Props> = ({
       }
       return true;
     };
-    const handleResize = () => {
+    const recalcShouldExtraMenuBeDisplayed = () => {
       setIsExtraMenuDisplayed(getShouldExtraMenuBeDisplayed());
       if (!isExtraMenuDisplayed) {
         setIsExtraMenuOpened(false);
       }
     };
-    handleResize();
-    window.addEventListener("resize", handleResize);
+    recalcShouldExtraMenuBeDisplayed();
+    window.addEventListener("resize", recalcShouldExtraMenuBeDisplayed);
+    window.addEventListener("focus", recalcShouldExtraMenuBeDisplayed);
     return () => {
-      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("resize", recalcShouldExtraMenuBeDisplayed);
+      window.removeEventListener("focus", recalcShouldExtraMenuBeDisplayed);
     };
   }, [isExtraMenuDisplayed, minimumSpaceBetweenTitleAndExtra]);
   const title = (


### PR DESCRIPTION
Sometimes, buttons would be hidden inside a hamburger menu even when there is enough room to show the buttons normally instead. We used to recalculate if the button should be shown when the window is resized. This commit also recalculates the state when the window gains focus. This bug is hard to replicate reliably, so it is not guaranteed that this solution works.