### PR TITLE
Add operations filters

### DIFF
--- a/frontend/src/components/OperationFilterSelector/index.tsx
+++ b/frontend/src/components/OperationFilterSelector/index.tsx
@@ -1,0 +1,32 @@
+import { Radio, type RadioChangeEvent } from "antd";
+import type React from "react";
+
+interface Props {
+  value: OperationStatus;
+  onChange: (value: OperationStatus) => void;
+}
+
+export enum OperationStatus {
+  ALL = "all",
+  EXECUTING = "executing",
+  QUEUED = "queued",
+  COMPLETED = "completed",
+}
+
+export const OperationFilterSelector: React.FC<Props> = ({
+  value,
+  onChange,
+}) => {
+  return (
+    <Radio.Group
+      buttonStyle="solid"
+      defaultValue={value}
+      onChange={(e: RadioChangeEvent) => onChange(e.target.value)}
+    >
+      <Radio.Button value={OperationStatus.ALL}>All</Radio.Button>
+      <Radio.Button value={OperationStatus.EXECUTING}>Executing</Radio.Button>
+      <Radio.Button value={OperationStatus.QUEUED}>Queued</Radio.Button>
+      <Radio.Button value={OperationStatus.COMPLETED}>Completed</Radio.Button>
+    </Radio.Group>
+  );
+};

--- a/frontend/src/components/OperationsGrid/index.tsx
+++ b/frontend/src/components/OperationsGrid/index.tsx
@@ -1,10 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Table } from "antd";
 import type React from "react";
+import { useState } from "react";
 import { buildQueueStateClient } from "@/grpc/buildQueueStateClient";
-import { RequestMetadata } from "@/lib/grpc-client/build/bazel/remote/execution/v2/remote_execution";
+import {
+  ExecutionStage_Value,
+  RequestMetadata,
+} from "@/lib/grpc-client/build/bazel/remote/execution/v2/remote_execution";
 import type { OperationsFilterParams } from "@/routes/operations.index";
 import themeStyles from "@/theme/theme.module.css";
+import {
+  OperationFilterSelector,
+  OperationStatus,
+} from "../OperationFilterSelector";
 import OperationsInvocationFilter from "../OperationsInvocationFilter";
 import PortalAlert from "../PortalAlert";
 import getColumns from "./Columns";
@@ -16,8 +24,32 @@ interface Props {
 }
 
 const OperationsTable: React.FC<Props> = ({ filter }) => {
+  const [statusFilter, setStatusFilter] = useState(OperationStatus.ALL);
+
+  const executionStageByStatus: Record<
+    OperationStatus,
+    ExecutionStage_Value | undefined
+  > = {
+    [OperationStatus.ALL]: undefined,
+    [OperationStatus.QUEUED]: ExecutionStage_Value.QUEUED,
+    [OperationStatus.EXECUTING]: ExecutionStage_Value.EXECUTING,
+    [OperationStatus.COMPLETED]: ExecutionStage_Value.COMPLETED,
+  };
+  const executionStage = executionStageByStatus[statusFilter];
+
+  const queryClient = useQueryClient();
+
+  const handleFilterChange = (value: OperationStatus) => {
+    setStatusFilter(value);
+
+    // Invalidate query to allow the query to refetch the operations
+    queryClient.invalidateQueries({
+      queryKey: ["operationsTable"],
+    });
+  };
+
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["operationsTable", filter],
+    queryKey: ["operationsTable", filter, statusFilter],
     queryFn: buildQueueStateClient.listOperations.bind(window, {
       pageSize: PAGE_SIZE,
       filterInvocationId: filter
@@ -28,11 +60,11 @@ const OperationsTable: React.FC<Props> = ({ filter }) => {
             ).finish(),
           }
         : undefined,
+      filterStage: executionStage,
     }),
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnMount: "always",
   });
-
   if (isError) {
     return (
       <PortalAlert
@@ -49,6 +81,14 @@ const OperationsTable: React.FC<Props> = ({ filter }) => {
 
   return (
     <>
+      <div
+        style={{ display: "flex", justifyContent: "flex-end", marginBottom: 8 }}
+      >
+        <OperationFilterSelector
+          value={statusFilter}
+          onChange={handleFilterChange}
+        />
+      </div>
       <OperationsInvocationFilter filter={filter} />
       <Table
         loading={isLoading}


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #289

Add the ability to filter operations based on their status. Available statues are `completed`, `executing`, and `queued`.