### PR TITLE
Fix a wraparound bug in next slice for db cleanup

### DIFF
--- a/internal/database/dbcleanupservice/BUILD.bazel
+++ b/internal/database/dbcleanupservice/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     srcs = [
         "dbcleanupservice_test.go",
         "lockinvocations_test.go",
+        "next_slice_test.go",
         "remove_old_invocations_test.go",
         "remove_orphaned_test_targets_test.go",
         "remove_target_kind_mappings_test.go",

--- a/internal/database/dbcleanupservice/next_slice.go
+++ b/internal/database/dbcleanupservice/next_slice.go
@@ -7,6 +7,18 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/util"
 )
 
+// CalculateNextSlice is exported for testing.
+func CalculateNextSlice(counter, totalPages, runsPerHour int64) (from, count int64) {
+	count = max(totalPages/runsPerHour, 1)
+	from = (counter * count) % totalPages
+	prevFrom := ((counter - 1) * count) % totalPages
+
+	if from < prevFrom {
+		return 0, count + from
+	}
+	return from, count
+}
+
 // nextSlice calculates the physical page range for the current cleanup
 // tick. It automatically adjusts the start page and number of pages
 // with the goal of iterating through the entire table in one hour.
@@ -18,11 +30,8 @@ func (dc *DbCleanupService) nextSlice(ctx context.Context, table string) (from, 
 	if err != nil {
 		return 0, 0, util.StatusWrapf(err, "Failed to get pages for %s", table)
 	}
-
 	totalPages := max(int64(pages32), 1)
 	runsPerHour := max(int64(time.Hour/dc.cleanupInterval), 1)
-	count = max(totalPages/runsPerHour, 1)
-	from = (dc.counter * count) % totalPages
-
+	from, count = CalculateNextSlice(dc.counter, totalPages, runsPerHour)
 	return from, count, nil
 }

--- a/internal/database/dbcleanupservice/next_slice_test.go
+++ b/internal/database/dbcleanupservice/next_slice_test.go
@@ -1,0 +1,39 @@
+package dbcleanupservice_test
+
+import (
+	"testing"
+
+	"github.com/buildbarn/bb-portal/internal/database/dbcleanupservice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateNextSlice(t *testing.T) {
+	tests := []struct {
+		name          string
+		counter       int64
+		totalPages    int64
+		runsPerHour   int64
+		expectedFrom  int64
+		expectedCount int64
+	}{
+		// name, counter, totalPages, runsPerHour, expectedFrom, expectedCount
+		{"counter 0", 0, 100, 10, 0, 10},
+		{"runs > pages", 0, 5, 10, 0, 1},
+		{"pages 1", 0, 1, 10, 0, 1},
+		{"mid cycle step 1", 1, 100, 10, 10, 10},
+		{"mid cycle step 2", 2, 100, 10, 20, 10},
+		{"perfect wrap", 10, 100, 10, 0, 10},
+		{"post perfect wrap", 11, 100, 10, 10, 10},
+		{"pre stretch wrap", 3, 10, 3, 9, 3},
+		{"stretch wrap trigger", 4, 10, 3, 0, 5},
+		{"post stretch wrap", 5, 10, 3, 5, 3},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			from, count := dbcleanupservice.CalculateNextSlice(test.counter, test.totalPages, test.runsPerHour)
+			require.Equal(t, test.expectedFrom, from)
+			require.Equal(t, test.expectedCount, count)
+		})
+	}
+}


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #290

The function `nextSlice` had a bug where sometimes it could miss pages when the counter wrapped around. 