### PR TITLE
Improve cleanup throughput for large deployments

### DIFF
--- a/internal/bep/bep_service.go
+++ b/internal/bep/bep_service.go
@@ -66,6 +66,7 @@ func NewBuildEventProtocolService(
 	databaseCleanupService, err := dbcleanupservice.NewDbCleanupService(
 		dbClient,
 		clock.SystemClock,
+		dbcleanupservice.NewTimedBatcher(clock.SystemClock, 1*time.Second, 1<<7, 1<<20),
 		configuration.DatabaseCleanupConfiguration,
 		tracerProvider,
 	)

--- a/internal/database/dbcleanupservice/BUILD.bazel
+++ b/internal/database/dbcleanupservice/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "dbcleanupservice",
     srcs = [
+        "batcher.go",
         "compact_logs.go",
         "dbcleanupservice.go",
         "delete_incomplete_logs.go",
@@ -17,7 +18,6 @@ go_library(
     importpath = "github.com/buildbarn/bb-portal/internal/database/dbcleanupservice",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//ent/gen/ent",
         "//ent/gen/ent/authenticateduser",
         "//ent/gen/ent/bazelinvocation",
         "//ent/gen/ent/build",
@@ -34,6 +34,7 @@ go_library(
         "@com_github_buildbarn_bb_storage//pkg/clock",
         "@com_github_buildbarn_bb_storage//pkg/program",
         "@com_github_buildbarn_bb_storage//pkg/util",
+        "@com_github_google_uuid//:uuid",
         "@com_github_klauspost_compress//zstd",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
@@ -44,6 +45,7 @@ go_library(
 go_test(
     name = "dbcleanupservice_test",
     srcs = [
+        "batcher_test.go",
         "dbcleanupservice_test.go",
         "lockinvocations_test.go",
         "next_slice_test.go",

--- a/internal/database/dbcleanupservice/batcher.go
+++ b/internal/database/dbcleanupservice/batcher.go
@@ -1,0 +1,61 @@
+package dbcleanupservice
+
+import (
+	"context"
+	"time"
+
+	"github.com/buildbarn/bb-storage/pkg/clock"
+)
+
+// Batcher is a utility that batches executions of an operation into
+// chunks.
+type Batcher interface {
+	Batch(context.Context, func(context.Context, int64) (int64, error)) (int64, error)
+}
+
+type timedBatcher struct {
+	clock          clock.Clock
+	targetDuration time.Duration
+	minBatchSize   int64
+	maxBatchSize   int64
+}
+
+// NewTimedBatcher returns a batcher that uses exponential growth to
+// reach a target duration.
+func NewTimedBatcher(clock clock.Clock, targetDuration time.Duration, minBatchSize, maxBatchSize int64) Batcher {
+	return &timedBatcher{
+		clock:          clock,
+		targetDuration: targetDuration,
+		minBatchSize:   minBatchSize,
+		maxBatchSize:   maxBatchSize,
+	}
+}
+
+func (b *timedBatcher) Batch(ctx context.Context, operation func(context.Context, int64) (int64, error)) (int64, error) {
+	var totalProcessed int64
+
+	batchLimit := b.minBatchSize
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return totalProcessed, err
+		}
+
+		start := b.clock.Now()
+		processed, err := operation(ctx, batchLimit)
+		totalProcessed += processed
+		if err != nil {
+			return totalProcessed, err
+		}
+		// Fewer rows were processed than the batch limit, we are done.
+		if processed < batchLimit {
+			return totalProcessed, nil
+		}
+
+		duration := b.clock.Now().Sub(start)
+		if duration < b.targetDuration {
+			// Query was fast, double limit and try again.
+			batchLimit = min(2*batchLimit, b.maxBatchSize)
+		}
+	}
+}

--- a/internal/database/dbcleanupservice/batcher_test.go
+++ b/internal/database/dbcleanupservice/batcher_test.go
@@ -1,0 +1,139 @@
+package dbcleanupservice_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/buildbarn/bb-portal/internal/database/dbcleanupservice"
+	"github.com/buildbarn/bb-portal/internal/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestTimedBatcher(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClock := mock.NewMockClock(ctrl)
+	ctx := context.Background()
+
+	targetDuration := 1 * time.Second
+	minBatchSize := int64(100)
+	maxBatchSize := int64(1000)
+
+	t.Run("ImmediateCompletion", func(t *testing.T) {
+		batcher := dbcleanupservice.NewTimedBatcher(mockClock, targetDuration, minBatchSize, maxBatchSize)
+
+		mockClock.EXPECT().Now().Return(time.Unix(0, 0))
+
+		operation := func(ctx context.Context, limit int64) (int64, error) {
+			require.Equal(t, int64(100), limit)
+			return 50, nil // Processed less than limit, should terminate immediately
+		}
+
+		total, err := batcher.Batch(ctx, operation)
+		require.NoError(t, err)
+		require.Equal(t, int64(50), total)
+	})
+
+	t.Run("ExponentialGrowthAndClamping", func(t *testing.T) {
+		batcher := dbcleanupservice.NewTimedBatcher(mockClock, targetDuration, minBatchSize, maxBatchSize)
+		startTime := time.Unix(0, 0)
+
+		// Batch 1: Limit 100
+		mockClock.EXPECT().Now().Return(startTime)
+		mockClock.EXPECT().Now().Return(startTime.Add(100 * time.Millisecond)) // fast
+
+		// Batch 2: Limit 200
+		mockClock.EXPECT().Now().Return(startTime)
+		mockClock.EXPECT().Now().Return(startTime.Add(100 * time.Millisecond)) // fast
+
+		// Batch 3: Limit 400
+		mockClock.EXPECT().Now().Return(startTime)
+		mockClock.EXPECT().Now().Return(startTime.Add(100 * time.Millisecond)) // fast
+
+		// Batch 4: Limit 800
+		mockClock.EXPECT().Now().Return(startTime)
+		mockClock.EXPECT().Now().Return(startTime.Add(100 * time.Millisecond)) // fast
+
+		// Batch 5: Limit 1000 (Clamped from 1600)
+		mockClock.EXPECT().Now().Return(startTime)
+
+		expectedLimits := []int64{100, 200, 400, 800, 1000}
+		callCount := 0
+
+		operation := func(ctx context.Context, limit int64) (int64, error) {
+			require.Equal(t, expectedLimits[callCount], limit)
+			callCount++
+
+			if limit == 1000 {
+				return 42, nil // Finish on the last capped batch
+			}
+			return limit, nil // Return full limit to trigger next loop
+		}
+
+		total, err := batcher.Batch(ctx, operation)
+		require.NoError(t, err)
+
+		// 100 + 200 + 400 + 800 + 42 = 1542
+		require.Equal(t, int64(1542), total)
+	})
+
+	t.Run("SlowQueryHaltsGrowth", func(t *testing.T) {
+		batcher := dbcleanupservice.NewTimedBatcher(mockClock, targetDuration, minBatchSize, maxBatchSize)
+		startTime := time.Unix(0, 0)
+
+		// Batch 1: Limit 100, takes 2 seconds (slower than target)
+		mockClock.EXPECT().Now().Return(startTime)
+		mockClock.EXPECT().Now().Return(startTime.Add(2 * time.Second))
+
+		// Batch 2: Limit should remain 100
+		mockClock.EXPECT().Now().Return(startTime)
+
+		callCount := 0
+		operation := func(ctx context.Context, limit int64) (int64, error) {
+			require.Equal(t, int64(100), limit)
+			callCount++
+			if callCount == 2 {
+				return 0, nil
+			}
+			return limit, nil
+		}
+
+		total, err := batcher.Batch(ctx, operation)
+		require.NoError(t, err)
+		require.Equal(t, int64(100), total)
+	})
+
+	t.Run("PropagatesOperationError", func(t *testing.T) {
+		batcher := dbcleanupservice.NewTimedBatcher(mockClock, targetDuration, minBatchSize, maxBatchSize)
+		expectedErr := errors.New("database connection lost")
+
+		mockClock.EXPECT().Now().Return(time.Unix(0, 0))
+
+		operation := func(ctx context.Context, limit int64) (int64, error) {
+			return 50, expectedErr
+		}
+
+		total, err := batcher.Batch(ctx, operation)
+		require.ErrorIs(t, err, expectedErr)
+		// Should still return the rows processed before the error
+		require.Equal(t, int64(50), total)
+	})
+
+	t.Run("ContextCancellation", func(t *testing.T) {
+		batcher := dbcleanupservice.NewTimedBatcher(mockClock, targetDuration, minBatchSize, maxBatchSize)
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel before we even start
+
+		operation := func(ctx context.Context, limit int64) (int64, error) {
+			t.Fatal("Operation should not be called if context is cancelled")
+			return 0, nil
+		}
+
+		total, err := batcher.Batch(cancelCtx, operation)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, int64(0), total)
+	})
+}

--- a/internal/database/dbcleanupservice/compact_logs.go
+++ b/internal/database/dbcleanupservice/compact_logs.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/buildbarn/bb-portal/ent/gen/ent"
 	"github.com/buildbarn/bb-portal/ent/gen/ent/bazelinvocation"
 	"github.com/buildbarn/bb-portal/internal/api/grpc/bes"
+	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-storage/pkg/util"
+	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 )
 
-func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation *ent.BazelInvocation) (err error) {
+func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, dbID int64, invocationID uuid.UUID) (err error) {
 	ctx, span := dc.tracer.Start(ctx, "DbCleanupService.normalizeInvocation")
 	defer func() {
 		if err != nil {
@@ -23,9 +24,9 @@ func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation 
 		span.End()
 	}()
 
-	span.SetAttributes(attribute.String("invocation.id", invocation.InvocationID.String()))
+	span.SetAttributes(attribute.String("invocation.id", invocationID.String()))
 
-	normalizedLogs, err := bes.GetNormalizedIncompleteBuildLogs(ctx, dc.db.Ent(), invocation.InvocationID)
+	normalizedLogs, err := bes.GetNormalizedIncompleteBuildLogs(ctx, dc.db.Ent(), invocationID)
 	if err != nil {
 		return util.StatusWrap(err, "Could not normalize log")
 	}
@@ -34,7 +35,6 @@ func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation 
 	if err != nil {
 		return util.StatusWrap(err, "Could not start transaction")
 	}
-
 	defer tx.Rollback()
 
 	encoder, err := zstd.NewWriter(nil)
@@ -46,6 +46,7 @@ func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation 
 	const chunkSize = 8 * 1024 * 1024 // 8MiB
 	line := int64(0)
 	buffer := make([]byte, 0, chunkSize/50)
+
 	for index := 0; index*chunkSize < len(normalizedLogs); index++ {
 		start := index * chunkSize
 		end := min((index+1)*chunkSize, len(normalizedLogs))
@@ -60,14 +61,31 @@ func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation 
 			lastLineIndex = firstLineIndex + int64(lineCount)
 		}
 		data = encoder.EncodeAll(data, buffer[:0])
+
 		_, err = tx.BuildLogChunk.Create().
-			SetBazelInvocation(invocation).
+			SetBazelInvocationID(dbID).
 			SetData(data).
 			SetChunkIndex(index).
 			SetFirstLineIndex(firstLineIndex).
 			SetLastLineIndex(lastLineIndex).
 			Save(ctx)
 		if err != nil {
+			tx.Rollback()
+
+			alreadyNormalized, checkErr := dc.db.Ent().BazelInvocation.Query().
+				Where(
+					bazelinvocation.IDEQ(dbID),
+					bazelinvocation.BepCompleted(true),
+					bazelinvocation.HasIncompleteBuildLogs(),
+					bazelinvocation.Not(bazelinvocation.HasBuildLogChunks()),
+				).Exist(ctx)
+
+			// The invocation was already normalized so we ignore the
+			// error.
+			if checkErr == nil && alreadyNormalized {
+				return nil
+			}
+
 			return util.StatusWrap(err, "Could not save log chunk")
 		}
 
@@ -88,32 +106,40 @@ func (dc *DbCleanupService) normalizeInvocation(ctx context.Context, invocation 
 // CompactLogs compacts incomplete build logs by merging log entries for
 // the same invocation.
 func (dc *DbCleanupService) CompactLogs(ctx context.Context) (int64, error) {
-	invocations, err := dc.db.Ent().BazelInvocation.Query().
-		Where(
-			bazelinvocation.BepCompleted(true),
-			bazelinvocation.HasIncompleteBuildLogs(),
-			bazelinvocation.Not(
-				bazelinvocation.HasBuildLogChunks(),
-			),
-		).
-		All(ctx)
+	start, count, err := dc.nextSlice(ctx, "bazel_invocations")
 	if err != nil {
-		return 0, util.StatusWrap(err, "Failed to query invocations with incomplete build logs")
+		return 0, err
 	}
 
-	errs := make([]error, 0, len(invocations))
-	for _, invocation := range invocations {
-		err = dc.normalizeInvocation(ctx, invocation)
+	compacted, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		invocations, err := dc.db.Sqlc().GetInvocationsForLogCompactionFromPages(ctx, sqlc.GetInvocationsForLogCompactionFromPagesParams{
+			FromPage:   start,
+			Pages:      count,
+			BatchLimit: limit,
+		})
 		if err != nil {
-			errs = append(errs, err)
+			return 0, util.StatusWrap(err, "Failed to query invocations for log compaction")
 		}
-	}
 
-	succeeded := int64(len(invocations) - len(errs))
-	if len(errs) != 0 {
-		err = util.StatusFromMultiple(errs)
-		return succeeded, err
-	}
+		if len(invocations) == 0 {
+			return 0, nil
+		}
 
-	return succeeded, nil
+		errs := make([]error, 0, len(invocations))
+		for _, inv := range invocations {
+			err = dc.normalizeInvocation(ctx, inv.ID, inv.InvocationID)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		succeeded := int64(len(invocations) - len(errs))
+		if len(errs) != 0 {
+			return succeeded, util.StatusFromMultiple(errs)
+		}
+
+		return int64(len(invocations)), nil
+	})
+
+	return compacted, err
 }

--- a/internal/database/dbcleanupservice/dbcleanupservice.go
+++ b/internal/database/dbcleanupservice/dbcleanupservice.go
@@ -35,6 +35,7 @@ import (
 //  7. Removing unused targets.
 type DbCleanupService struct {
 	db                       database.Client
+	batcher                  Batcher
 	counter                  int64
 	clock                    clock.Clock
 	cleanupInterval          time.Duration
@@ -47,6 +48,7 @@ type DbCleanupService struct {
 func NewDbCleanupService(
 	db database.Client,
 	clock clock.Clock,
+	batcher Batcher,
 	cleanupConfiguration *bb_portal.BuildEventStreamService_DatabaseCleanupConfiguration,
 	tracerProvider trace.TracerProvider,
 ) (*DbCleanupService, error) {
@@ -69,6 +71,7 @@ func NewDbCleanupService(
 		db:                       db,
 		counter:                  rand.Int64N(65536),
 		clock:                    clock,
+		batcher:                  batcher,
 		cleanupInterval:          cleanupInterval.AsDuration(),
 		invocationMessageTimeout: invocationMessageTimeout.AsDuration(),
 		invocationRetention:      invocationRetention.AsDuration(),

--- a/internal/database/dbcleanupservice/dbcleanupservice_test.go
+++ b/internal/database/dbcleanupservice/dbcleanupservice_test.go
@@ -45,13 +45,14 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func getNewDbCleanupService(db database.Client, clock clock.Clock, traceProvider trace.TracerProvider) (*dbcleanupservice.DbCleanupService, error) {
+func getNewDbCleanupService(db database.Client, c clock.Clock, traceProvider trace.TracerProvider) (*dbcleanupservice.DbCleanupService, error) {
 	cleanupConfiguration := &bb_portal.BuildEventStreamService_DatabaseCleanupConfiguration{
 		CleanupInterval:          durationpb.New(1 * time.Minute),
 		InvocationMessageTimeout: durationpb.New(30 * time.Second),
 		InvocationRetention:      durationpb.New(30 * time.Minute),
 	}
-	return dbcleanupservice.NewDbCleanupService(db, clock, cleanupConfiguration, traceProvider)
+	batcher := dbcleanupservice.NewTimedBatcher(clock.SystemClock, 1*time.Second, 128, 1<<20)
+	return dbcleanupservice.NewDbCleanupService(db, c, batcher, cleanupConfiguration, traceProvider)
 }
 
 func populateIncompleteBuildLog(t *testing.T, ctx context.Context, client *ent.Client, invocationDbID int64) {

--- a/internal/database/dbcleanupservice/delete_incomplete_logs.go
+++ b/internal/database/dbcleanupservice/delete_incomplete_logs.go
@@ -16,9 +16,12 @@ func (dc *DbCleanupService) DeleteIncompleteLogs(ctx context.Context) (int64, er
 		return 0, err
 	}
 
-	deleted, err := dc.db.Sqlc().DeleteIncompleteLogsFromPages(ctx, sqlc.DeleteIncompleteLogsFromPagesParams{
-		FromPage: start,
-		Pages:    count,
+	deleted, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		return dc.db.Sqlc().DeleteIncompleteLogsFromPages(ctx, sqlc.DeleteIncompleteLogsFromPagesParams{
+			FromPage:   start,
+			Pages:      count,
+			BatchLimit: limit,
+		})
 	})
 	if err != nil {
 		return 0, util.StatusWrap(err, "Could not delete incompleted build logs")

--- a/internal/database/dbcleanupservice/lockinvocations.go
+++ b/internal/database/dbcleanupservice/lockinvocations.go
@@ -17,14 +17,17 @@ func (dc *DbCleanupService) LockInvocationsWithNoRecentEvents(ctx context.Contex
 		return 0, err
 	}
 
-	updatedRows, err := dc.db.Sqlc().LockStaleInvocationsFromPages(
-		ctx,
-		sqlc.LockStaleInvocationsFromPagesParams{
-			FromPage:   start,
-			Pages:      count,
-			CutoffTime: cutoffTime,
-		},
-	)
+	updatedRows, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		return dc.db.Sqlc().LockStaleInvocationsFromPages(
+			ctx,
+			sqlc.LockStaleInvocationsFromPagesParams{
+				FromPage:   start,
+				Pages:      count,
+				CutoffTime: cutoffTime,
+				BatchLimit: limit,
+			},
+		)
+	})
 	if err != nil {
 		return 0, util.StatusWrap(err, "Failed to lock invocations")
 	}

--- a/internal/database/dbcleanupservice/remove_old_invocations.go
+++ b/internal/database/dbcleanupservice/remove_old_invocations.go
@@ -18,10 +18,13 @@ func (dc *DbCleanupService) RemoveOldInvocations(ctx context.Context) (int64, er
 		return 0, err
 	}
 
-	deleted, err := dc.db.Sqlc().DeleteOldInvocationsFromPages(ctx, sqlc.DeleteOldInvocationsFromPagesParams{
-		FromPage:   start,
-		Pages:      count,
-		CutoffTime: cutoffTime,
+	deleted, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		return dc.db.Sqlc().DeleteOldInvocationsFromPages(ctx, sqlc.DeleteOldInvocationsFromPagesParams{
+			FromPage:   start,
+			Pages:      count,
+			CutoffTime: cutoffTime,
+			BatchLimit: limit,
+		})
 	})
 	if err != nil {
 		return 0, util.StatusWrap(err, "Failed to remove old invocations")

--- a/internal/database/dbcleanupservice/remove_orphaned_test_targets.go
+++ b/internal/database/dbcleanupservice/remove_orphaned_test_targets.go
@@ -16,9 +16,12 @@ func (dc *DbCleanupService) RemoveOrphanedTestTargets(ctx context.Context) (int6
 		return 0, err
 	}
 
-	deleted, err := dc.db.Sqlc().DeleteOrphanedTestTargetsFromPages(ctx, sqlc.DeleteOrphanedTestTargetsFromPagesParams{
-		FromPage: start,
-		Pages:    count,
+	deleted, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		return dc.db.Sqlc().DeleteOrphanedTestTargetsFromPages(ctx, sqlc.DeleteOrphanedTestTargetsFromPagesParams{
+			FromPage:   start,
+			Pages:      count,
+			BatchLimit: limit,
+		})
 	})
 	if err != nil {
 		return 0, util.StatusWrap(err, "Failed to remove orphaned test targets")

--- a/internal/database/dbcleanupservice/remove_target_kind_mappings.go
+++ b/internal/database/dbcleanupservice/remove_target_kind_mappings.go
@@ -16,9 +16,12 @@ func (dc *DbCleanupService) RemoveTargetKindMappings(ctx context.Context) (int64
 		return 0, err
 	}
 
-	deleted, err := dc.db.Sqlc().DeleteTargetKindMappingsFromPages(ctx, sqlc.DeleteTargetKindMappingsFromPagesParams{
-		FromPage: start,
-		Pages:    count,
+	deleted, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		return dc.db.Sqlc().DeleteTargetKindMappingsFromPages(ctx, sqlc.DeleteTargetKindMappingsFromPagesParams{
+			FromPage:   start,
+			Pages:      count,
+			BatchLimit: limit,
+		})
 	})
 	if err != nil {
 		return 0, util.StatusWrap(err, "Failed to remove old TargetKindMappings")

--- a/internal/database/dbcleanupservice/remove_unused_targets.go
+++ b/internal/database/dbcleanupservice/remove_unused_targets.go
@@ -16,9 +16,12 @@ func (dc *DbCleanupService) RemoveUnusedTargets(ctx context.Context) (int64, err
 		return 0, err
 	}
 
-	deleted, err := dc.db.Sqlc().DeleteUnusedTargetsFromPages(ctx, sqlc.DeleteUnusedTargetsFromPagesParams{
-		FromPage: start,
-		Pages:    count,
+	deleted, err := dc.batcher.Batch(ctx, func(ctx context.Context, limit int64) (int64, error) {
+		return dc.db.Sqlc().DeleteUnusedTargetsFromPages(ctx, sqlc.DeleteUnusedTargetsFromPagesParams{
+			FromPage:   start,
+			Pages:      count,
+			BatchLimit: limit,
+		})
 	})
 	if err != nil {
 		return 0, util.StatusWrap(err, "Failed to remove unused Targets")

--- a/internal/database/sqlc/bazel_invocations.sql.go
+++ b/internal/database/sqlc/bazel_invocations.sql.go
@@ -70,25 +70,89 @@ func (q *Queries) CreateBazelInvocation(ctx context.Context, arg CreateBazelInvo
 
 const deleteOldInvocationsFromPages = `-- name: DeleteOldInvocationsFromPages :execrows
 DELETE FROM bazel_invocations
-WHERE
-    ctid >= format('(%s,0)', $1::bigint)::tid
-    AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
-    AND created_timestamp < $3::timestamptz
-    AND bep_completed = true
+WHERE ctid IN(
+    SELECT ctid
+    FROM bazel_invocations
+    WHERE
+      ctid >= format('(%s,0)', $1::bigint)::tid
+      AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+      AND created_timestamp < $3::timestamptz
+      AND bep_completed = true
+    FOR UPDATE SKIP LOCKED
+    LIMIT $4::bigint
+)
 `
 
 type DeleteOldInvocationsFromPagesParams struct {
 	FromPage   int64
 	Pages      int64
 	CutoffTime time.Time
+	BatchLimit int64
 }
 
 func (q *Queries) DeleteOldInvocationsFromPages(ctx context.Context, arg DeleteOldInvocationsFromPagesParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteOldInvocationsFromPages, arg.FromPage, arg.Pages, arg.CutoffTime)
+	result, err := q.db.ExecContext(ctx, deleteOldInvocationsFromPages,
+		arg.FromPage,
+		arg.Pages,
+		arg.CutoffTime,
+		arg.BatchLimit,
+	)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const getInvocationsForLogCompactionFromPages = `-- name: GetInvocationsForLogCompactionFromPages :many
+SELECT id, invocation_id
+FROM bazel_invocations
+WHERE
+    ctid >= format('(%s,0)', $1::bigint)::tid
+    AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+    AND bep_completed = true
+    AND EXISTS (
+        SELECT 1 FROM incomplete_build_logs
+        WHERE bazel_invocation_id = bazel_invocations.id
+    )
+    AND NOT EXISTS (
+        SELECT 1 FROM build_log_chunks
+        WHERE bazel_invocation_build_log_chunks = bazel_invocations.id
+    )
+LIMIT $3::bigint
+`
+
+type GetInvocationsForLogCompactionFromPagesParams struct {
+	FromPage   int64
+	Pages      int64
+	BatchLimit int64
+}
+
+type GetInvocationsForLogCompactionFromPagesRow struct {
+	ID           int64
+	InvocationID uuid.UUID
+}
+
+func (q *Queries) GetInvocationsForLogCompactionFromPages(ctx context.Context, arg GetInvocationsForLogCompactionFromPagesParams) ([]GetInvocationsForLogCompactionFromPagesRow, error) {
+	rows, err := q.db.QueryContext(ctx, getInvocationsForLogCompactionFromPages, arg.FromPage, arg.Pages, arg.BatchLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetInvocationsForLogCompactionFromPagesRow
+	for rows.Next() {
+		var i GetInvocationsForLogCompactionFromPagesRow
+		if err := rows.Scan(&i.ID, &i.InvocationID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const lockBazelInvocationCompletion = `-- name: LockBazelInvocationCompletion :one
@@ -113,25 +177,37 @@ func (q *Queries) LockBazelInvocationCompletion(ctx context.Context, id int64) (
 const lockStaleInvocationsFromPages = `-- name: LockStaleInvocationsFromPages :execrows
 UPDATE bazel_invocations
 SET bep_completed = true
-WHERE
-    ctid >= format('(%s,0)', $1::bigint)::tid
-    AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
-    AND bep_completed = false
-    AND EXISTS (
-        SELECT 1 FROM event_metadata em
-        WHERE em.bazel_invocation_id = bazel_invocations.id
-        AND em.event_received_at <= $3::timestamptz
-    )
+WHERE ctid IN (
+    SELECT ctid 
+    FROM bazel_invocations
+    WHERE
+        ctid >= format('(%s,0)', $1::bigint)::tid
+        AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+        AND bep_completed = false
+        AND EXISTS (
+            SELECT 1 FROM event_metadata em
+            WHERE em.bazel_invocation_id = bazel_invocations.id
+            AND em.event_received_at <= $3::timestamptz
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT $4::bigint
+)
 `
 
 type LockStaleInvocationsFromPagesParams struct {
 	FromPage   int64
 	Pages      int64
 	CutoffTime time.Time
+	BatchLimit int64
 }
 
 func (q *Queries) LockStaleInvocationsFromPages(ctx context.Context, arg LockStaleInvocationsFromPagesParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, lockStaleInvocationsFromPages, arg.FromPage, arg.Pages, arg.CutoffTime)
+	result, err := q.db.ExecContext(ctx, lockStaleInvocationsFromPages,
+		arg.FromPage,
+		arg.Pages,
+		arg.CutoffTime,
+		arg.BatchLimit,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/sqlc/incomplete_build_logs.sql.go
+++ b/internal/database/sqlc/incomplete_build_logs.sql.go
@@ -40,26 +40,33 @@ func (q *Queries) CreateIncompleteBuildLogs(ctx context.Context, arg CreateIncom
 }
 
 const deleteIncompleteLogsFromPages = `-- name: DeleteIncompleteLogsFromPages :execrows
-DELETE FROM incomplete_build_logs l
-USING bazel_invocations AS i
-WHERE
-    l.bazel_invocation_id = i.id
-    AND l.ctid >= format('(%s,0)', $1::bigint)::tid
-    AND l.ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
-    AND i.bep_completed = true
-    AND EXISTS (
-        SELECT 1 FROM build_log_chunks c
-        WHERE c.bazel_invocation_build_log_chunks = i.id
-    )
+DELETE FROM incomplete_build_logs
+WHERE ctid IN (
+    SELECT l.ctid
+    FROM incomplete_build_logs l
+    JOIN bazel_invocations AS i ON i.id = l.bazel_invocation_id
+    WHERE
+        l.bazel_invocation_id = i.id
+        AND l.ctid >= format('(%s,0)', $1::bigint)::tid
+        AND l.ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+        AND i.bep_completed = true
+        AND EXISTS (
+            SELECT 1 FROM build_log_chunks c
+            WHERE c.bazel_invocation_build_log_chunks = i.id
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT $3::bigint
+)
 `
 
 type DeleteIncompleteLogsFromPagesParams struct {
-	FromPage int64
-	Pages    int64
+	FromPage   int64
+	Pages      int64
+	BatchLimit int64
 }
 
 func (q *Queries) DeleteIncompleteLogsFromPages(ctx context.Context, arg DeleteIncompleteLogsFromPagesParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteIncompleteLogsFromPages, arg.FromPage, arg.Pages)
+	result, err := q.db.ExecContext(ctx, deleteIncompleteLogsFromPages, arg.FromPage, arg.Pages, arg.BatchLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/sqlc/querier.go
+++ b/internal/database/sqlc/querier.go
@@ -49,6 +49,7 @@ type Querier interface {
 	DeleteUnusedTargetsFromPages(ctx context.Context, arg DeleteUnusedTargetsFromPagesParams) (int64, error)
 	FindMappedTargets(ctx context.Context, arg FindMappedTargetsParams) ([]FindMappedTargetsRow, error)
 	FindTargets(ctx context.Context, arg FindTargetsParams) ([]FindTargetsRow, error)
+	GetInvocationsForLogCompactionFromPages(ctx context.Context, arg GetInvocationsForLogCompactionFromPagesParams) ([]GetInvocationsForLogCompactionFromPagesRow, error)
 	GetOrCreateEventMetadata(ctx context.Context, bazelInvocationID int64) (GetOrCreateEventMetadataRow, error)
 	LockBazelInvocationCompletion(ctx context.Context, id int64) (LockBazelInvocationCompletionRow, error)
 	LockStaleInvocationsFromPages(ctx context.Context, arg LockStaleInvocationsFromPagesParams) (int64, error)

--- a/internal/database/sqlc/target_kind_mappings.sql.go
+++ b/internal/database/sqlc/target_kind_mappings.sql.go
@@ -41,22 +41,28 @@ func (q *Queries) CreateTargetKindMappingsBulk(ctx context.Context, arg CreateTa
 }
 
 const deleteTargetKindMappingsFromPages = `-- name: DeleteTargetKindMappingsFromPages :execrows
-DELETE FROM target_kind_mappings m
-USING bazel_invocations AS i
-WHERE
-    m.bazel_invocation_id = i.id
-    AND m.ctid >= format('(%s,0)', $1::bigint)::tid
-    AND m.ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
-    AND i.bep_completed = true
+DELETE FROM target_kind_mappings
+WHERE ctid IN (
+    SELECT m.ctid FROM target_kind_mappings m
+    JOIN bazel_invocations AS i ON i.id = m.bazel_invocation_id
+    WHERE
+        m.bazel_invocation_id = i.id
+        AND m.ctid >= format('(%s,0)', $1::bigint)::tid
+        AND m.ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+        AND i.bep_completed = true
+    FOR UPDATE SKIP LOCKED
+    LIMIT $3::bigint
+)
 `
 
 type DeleteTargetKindMappingsFromPagesParams struct {
-	FromPage int64
-	Pages    int64
+	FromPage   int64
+	Pages      int64
+	BatchLimit int64
 }
 
 func (q *Queries) DeleteTargetKindMappingsFromPages(ctx context.Context, arg DeleteTargetKindMappingsFromPagesParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteTargetKindMappingsFromPages, arg.FromPage, arg.Pages)
+	result, err := q.db.ExecContext(ctx, deleteTargetKindMappingsFromPages, arg.FromPage, arg.Pages, arg.BatchLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/sqlc/targets.sql.go
+++ b/internal/database/sqlc/targets.sql.go
@@ -86,30 +86,37 @@ func (q *Queries) CreateTargets(ctx context.Context, arg CreateTargetsParams) ([
 
 const deleteUnusedTargetsFromPages = `-- name: DeleteUnusedTargetsFromPages :execrows
 DELETE FROM targets
-WHERE
-    ctid >= format('(%s,0)', $1::bigint)::tid
-    AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
-    AND (
-        NOT EXISTS (
-            SELECT 1 FROM "invocation_targets" 
-            WHERE "target_invocation_targets" = "targets"."id"
+WHERE ctid IN (
+    SELECT ctid
+    FROM targets
+    WHERE
+        ctid >= format('(%s,0)', $1::bigint)::tid
+        AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+        AND (
+            NOT EXISTS (
+                SELECT 1 FROM "invocation_targets" 
+                WHERE "target_invocation_targets" = "targets"."id"
+            )
         )
-    )
-    AND (
-        NOT EXISTS (
-            SELECT 1 FROM "target_kind_mappings" 
-            WHERE "target_id" = "targets"."id"
+        AND (
+            NOT EXISTS (
+                SELECT 1 FROM "target_kind_mappings" 
+                WHERE "target_id" = "targets"."id"
+            )
         )
-    )
+    FOR UPDATE SKIP LOCKED
+    LIMIT $3::bigint
+)
 `
 
 type DeleteUnusedTargetsFromPagesParams struct {
-	FromPage int64
-	Pages    int64
+	FromPage   int64
+	Pages      int64
+	BatchLimit int64
 }
 
 func (q *Queries) DeleteUnusedTargetsFromPages(ctx context.Context, arg DeleteUnusedTargetsFromPagesParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteUnusedTargetsFromPages, arg.FromPage, arg.Pages)
+	result, err := q.db.ExecContext(ctx, deleteUnusedTargetsFromPages, arg.FromPage, arg.Pages, arg.BatchLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/sqlc/test_targets.sql.go
+++ b/internal/database/sqlc/test_targets.sql.go
@@ -25,24 +25,31 @@ func (q *Queries) CreateTestTargetsBulk(ctx context.Context, targetIds []int64) 
 
 const deleteOrphanedTestTargetsFromPages = `-- name: DeleteOrphanedTestTargetsFromPages :execrows
 DELETE FROM test_targets
-WHERE
-    ctid >= format('(%s,0)', $1::bigint)::tid
-    AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
-    AND NOT EXISTS (
-        SELECT 1 
-        FROM invocation_targets it
-        JOIN test_summaries ts ON ts.invocation_target_test_summary = it.id
-        WHERE it.target_invocation_targets = test_targets.target_id
-    )
+WHERE ctid IN (
+    SELECT ctid
+    FROM test_targets
+    WHERE
+        ctid >= format('(%s,0)', $1::bigint)::tid
+        AND ctid < format('(%s,0)', $1::bigint + $2::bigint)::tid
+        AND NOT EXISTS (
+            SELECT 1 
+            FROM invocation_targets it
+            JOIN test_summaries ts ON ts.invocation_target_test_summary = it.id
+            WHERE it.target_invocation_targets = test_targets.target_id
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT $3::bigint
+)
 `
 
 type DeleteOrphanedTestTargetsFromPagesParams struct {
-	FromPage int64
-	Pages    int64
+	FromPage   int64
+	Pages      int64
+	BatchLimit int64
 }
 
 func (q *Queries) DeleteOrphanedTestTargetsFromPages(ctx context.Context, arg DeleteOrphanedTestTargetsFromPagesParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteOrphanedTestTargetsFromPages, arg.FromPage, arg.Pages)
+	result, err := q.db.ExecContext(ctx, deleteOrphanedTestTargetsFromPages, arg.FromPage, arg.Pages, arg.BatchLimit)
 	if err != nil {
 		return 0, err
 	}

--- a/sql/queries/bazel_invocations.sql
+++ b/sql/queries/bazel_invocations.sql
@@ -38,15 +38,21 @@ LIMIT 1;
 -- name: LockStaleInvocationsFromPages :execrows
 UPDATE bazel_invocations
 SET bep_completed = true
-WHERE
-    ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
-    AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
-    AND bep_completed = false
-    AND EXISTS (
-        SELECT 1 FROM event_metadata em
-        WHERE em.bazel_invocation_id = bazel_invocations.id
-        AND em.event_received_at <= sqlc.arg(cutoff_time)::timestamptz
-    );
+WHERE ctid IN (
+    SELECT ctid 
+    FROM bazel_invocations
+    WHERE
+        ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
+        AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
+        AND bep_completed = false
+        AND EXISTS (
+            SELECT 1 FROM event_metadata em
+            WHERE em.bazel_invocation_id = bazel_invocations.id
+            AND em.event_received_at <= sqlc.arg(cutoff_time)::timestamptz
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT sqlc.arg(batch_limit)::bigint
+);
 
 -- name: UpdateCompletedInvocationWithEndTimeFromEventMetadata :execrows
 UPDATE bazel_invocations bi
@@ -59,8 +65,32 @@ WHERE bi.id = em.bazel_invocation_id
 
 -- name: DeleteOldInvocationsFromPages :execrows
 DELETE FROM bazel_invocations
+WHERE ctid IN(
+    SELECT ctid
+    FROM bazel_invocations
+    WHERE
+      ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
+      AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
+      AND created_timestamp < sqlc.arg(cutoff_time)::timestamptz
+      AND bep_completed = true
+    FOR UPDATE SKIP LOCKED
+    LIMIT sqlc.arg(batch_limit)::bigint
+);
+
+-- name: GetInvocationsForLogCompactionFromPages :many
+SELECT id, invocation_id
+FROM bazel_invocations
 WHERE
     ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
     AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
-    AND created_timestamp < sqlc.arg(cutoff_time)::timestamptz
-    AND bep_completed = true;
+    AND bep_completed = true
+    AND EXISTS (
+        SELECT 1 FROM incomplete_build_logs
+        WHERE bazel_invocation_id = bazel_invocations.id
+    )
+    AND NOT EXISTS (
+        SELECT 1 FROM build_log_chunks
+        WHERE bazel_invocation_build_log_chunks = bazel_invocations.id
+    )
+LIMIT sqlc.arg(batch_limit)::bigint;
+

--- a/sql/queries/incomplete_build_logs.sql
+++ b/sql/queries/incomplete_build_logs.sql
@@ -15,14 +15,20 @@ FROM (
 ) AS input;
 
 -- name: DeleteIncompleteLogsFromPages :execrows
-DELETE FROM incomplete_build_logs l
-USING bazel_invocations AS i
-WHERE
-    l.bazel_invocation_id = i.id
-    AND l.ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
-    AND l.ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
-    AND i.bep_completed = true
-    AND EXISTS (
-        SELECT 1 FROM build_log_chunks c
-        WHERE c.bazel_invocation_build_log_chunks = i.id
-    );
+DELETE FROM incomplete_build_logs
+WHERE ctid IN (
+    SELECT l.ctid
+    FROM incomplete_build_logs l
+    JOIN bazel_invocations AS i ON i.id = l.bazel_invocation_id
+    WHERE
+        l.bazel_invocation_id = i.id
+        AND l.ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
+        AND l.ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
+        AND i.bep_completed = true
+        AND EXISTS (
+            SELECT 1 FROM build_log_chunks c
+            WHERE c.bazel_invocation_build_log_chunks = i.id
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT sqlc.arg(batch_limit)::bigint
+);

--- a/sql/queries/target_kind_mappings.sql
+++ b/sql/queries/target_kind_mappings.sql
@@ -33,10 +33,15 @@ JOIN target_kind_mappings m ON
     m.bazel_invocation_id = sqlc.arg(bazel_invocation_id);
 
 -- name: DeleteTargetKindMappingsFromPages :execrows
-DELETE FROM target_kind_mappings m
-USING bazel_invocations AS i
-WHERE
-    m.bazel_invocation_id = i.id
-    AND m.ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
-    AND m.ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
-    AND i.bep_completed = true;
+DELETE FROM target_kind_mappings
+WHERE ctid IN (
+    SELECT m.ctid FROM target_kind_mappings m
+    JOIN bazel_invocations AS i ON i.id = m.bazel_invocation_id
+    WHERE
+        m.bazel_invocation_id = i.id
+        AND m.ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
+        AND m.ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
+        AND i.bep_completed = true
+    FOR UPDATE SKIP LOCKED
+    LIMIT sqlc.arg(batch_limit)::bigint
+);

--- a/sql/queries/targets.sql
+++ b/sql/queries/targets.sql
@@ -38,18 +38,24 @@ RETURNING id, label, aspect, target_kind;
 
 -- name: DeleteUnusedTargetsFromPages :execrows
 DELETE FROM targets
-WHERE
-    ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
-    AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
-    AND (
-        NOT EXISTS (
-            SELECT 1 FROM "invocation_targets" 
-            WHERE "target_invocation_targets" = "targets"."id"
+WHERE ctid IN (
+    SELECT ctid
+    FROM targets
+    WHERE
+        ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
+        AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
+        AND (
+            NOT EXISTS (
+                SELECT 1 FROM "invocation_targets" 
+                WHERE "target_invocation_targets" = "targets"."id"
+            )
         )
-    )
-    AND (
-        NOT EXISTS (
-            SELECT 1 FROM "target_kind_mappings" 
-            WHERE "target_id" = "targets"."id"
+        AND (
+            NOT EXISTS (
+                SELECT 1 FROM "target_kind_mappings" 
+                WHERE "target_id" = "targets"."id"
+            )
         )
-    );
+    FOR UPDATE SKIP LOCKED
+    LIMIT sqlc.arg(batch_limit)::bigint
+);

--- a/sql/queries/test_targets.sql
+++ b/sql/queries/test_targets.sql
@@ -6,12 +6,18 @@ ON CONFLICT (target_id) DO NOTHING;
 
 -- name: DeleteOrphanedTestTargetsFromPages :execrows
 DELETE FROM test_targets
-WHERE
-    ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
-    AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
-    AND NOT EXISTS (
-        SELECT 1 
-        FROM invocation_targets it
-        JOIN test_summaries ts ON ts.invocation_target_test_summary = it.id
-        WHERE it.target_invocation_targets = test_targets.target_id
-    );
+WHERE ctid IN (
+    SELECT ctid
+    FROM test_targets
+    WHERE
+        ctid >= format('(%s,0)', sqlc.arg(from_page)::bigint)::tid
+        AND ctid < format('(%s,0)', sqlc.arg(from_page)::bigint + sqlc.arg(pages)::bigint)::tid
+        AND NOT EXISTS (
+            SELECT 1 
+            FROM invocation_targets it
+            JOIN test_summaries ts ON ts.invocation_target_test_summary = it.id
+            WHERE it.target_invocation_targets = test_targets.target_id
+        )
+    FOR UPDATE SKIP LOCKED
+    LIMIT sqlc.arg(batch_limit)::bigint
+);


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #291

The background jobs of bb-portal tries to spread out the labour over an hour. This commit improves cleanup throughput even further by splitting the size of the work done at each tick into smaller batches.