### PR TITLE
Fix broken pie chart legend column break

### DIFF
--- a/frontend/src/components/SummaryPieChart/index.module.css
+++ b/frontend/src/components/SummaryPieChart/index.module.css
@@ -1,0 +1,6 @@
+.legendContainer li {
+  break-inside: avoid-column;
+}
+.legendContainer {
+  break-inside: avoid-column;
+}

--- a/frontend/src/components/SummaryPieChart/index.tsx
+++ b/frontend/src/components/SummaryPieChart/index.tsx
@@ -10,6 +10,7 @@ import {
   type PieSectorShapeProps,
   Sector,
 } from "recharts";
+import styles from "./index.module.css";
 import { themeColor } from "./utils";
 
 // The `Legend` component uses `value`, `fill`,
@@ -149,7 +150,7 @@ const SummaryPieChart: React.FC<Props> = ({
           onMouseLeave={handleMouseLeave}
         />
       </PieChart>
-      <div style={{ breakInside: "avoid-column" }}>
+      <div className={styles.legendContainer}>
         {/* Use a React Portal to move the legend to outside of the PieChart. This makes layout easier */}
         <div ref={setPortalNode} />
       </div>


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #293

Make sure the column break in pie chart legends is not placed in the middle of a legend row.