### PR TITLE
Handle Command title horizontal overflow

### DIFF
--- a/frontend/src/components/LogViewer/index.module.css
+++ b/frontend/src/components/LogViewer/index.module.css
@@ -38,3 +38,9 @@
   background-attachment: local, local, scroll, scroll;
   padding: 6px 0.6em;
 }
+
+.titleWrapper {
+  text-overflow: "[…]";
+  overflow: hidden;
+  margin-right: 12px;
+}

--- a/frontend/src/components/LogViewer/index.tsx
+++ b/frontend/src/components/LogViewer/index.tsx
@@ -61,9 +61,14 @@ const LogViewerCard: React.FC<Props> = ({
           padding: "0px",
         },
       }}
+      reservedTitleWidth={300}
       className={!error ? styles.compactCard : undefined}
       icon={<FileSearchOutlined />}
-      titleBits={[title]}
+      titleBits={[
+        <div className={styles.titleWrapper} key={"title"}>
+          {title}
+        </div>,
+      ]}
       extraBits={[
         logDownloadUrl && (
           <Button icon={<DownloadOutlined />} type="primary">

--- a/frontend/src/components/PortalCard/index.tsx
+++ b/frontend/src/components/PortalCard/index.tsx
@@ -17,13 +17,26 @@ const { useToken } = theme;
 interface HeaderProps {
   headerBits: React.ReactNode[];
   className?: string;
+  limitTitleWidth?: boolean;
 }
 
 const Header = forwardRef<HTMLDivElement, HeaderProps>(
-  ({ headerBits, className }, ref) => {
+  ({ headerBits, className, limitTitleWidth }, ref) => {
     const actualClassName = [styles.header, className].join(" ");
     return (
-      <Space ref={ref} size="middle" className={actualClassName}>
+      <Space
+        ref={ref}
+        size="middle"
+        style={limitTitleWidth ? { display: "flex" } : {}}
+        className={actualClassName}
+        styles={
+          limitTitleWidth
+            ? {
+                item: { minWidth: `1px` },
+              }
+            : undefined
+        }
+      >
         {headerBits.map(
           (headerBit, index) =>
             headerBit && (
@@ -87,6 +100,7 @@ interface Props extends Omit<CardProps, "title" | "extra"> {
   titleBits: React.ReactNode[];
   extraBits?: React.ReactNode[];
   className?: string;
+  reservedTitleWidth?: number;
 }
 
 export const PortalCard: React.FC<Props> = ({
@@ -94,6 +108,7 @@ export const PortalCard: React.FC<Props> = ({
   titleBits,
   extraBits,
   className,
+  reservedTitleWidth, // If set, the extrabits will be displayed until the title gets this small, even if the title is overflowing
   ...cardProps
 }) => {
   const { token } = useToken();
@@ -109,7 +124,7 @@ export const PortalCard: React.FC<Props> = ({
       if (cardRef.current && titleRef.current && extraRef.current) {
         return (
           cardRef.current.clientWidth <
-          titleRef.current.clientWidth +
+          (reservedTitleWidth || titleRef.current.clientWidth) +
             extraRef.current.clientWidth +
             minimumSpaceBetweenTitleAndExtra
         );
@@ -129,11 +144,16 @@ export const PortalCard: React.FC<Props> = ({
       window.removeEventListener("resize", recalcShouldExtraMenuBeDisplayed);
       window.removeEventListener("focus", recalcShouldExtraMenuBeDisplayed);
     };
-  }, [isExtraMenuDisplayed, minimumSpaceBetweenTitleAndExtra]);
+  }, [
+    isExtraMenuDisplayed,
+    minimumSpaceBetweenTitleAndExtra,
+    reservedTitleWidth,
+  ]);
   const title = (
     <Header
       ref={titleRef}
       headerBits={[icon, ...titleBits]}
+      limitTitleWidth={!!reservedTitleWidth}
       className={styles.title}
     />
   );


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #293

The bazel command may very well be longer than what can fit in the title the log viewer. This truncates the command it it is too long.