### PR TITLE
Add fallback for empty home page

### DIFF
--- a/frontend/src/components/pages/Home/index.tsx
+++ b/frontend/src/components/pages/Home/index.tsx
@@ -1,3 +1,4 @@
+import { Navigate } from "@tanstack/react-router";
 import { Space, Typography } from "antd";
 import Uploader from "@/components/Uploader";
 import { env } from "@/utils/env";
@@ -41,12 +42,25 @@ const BepFileUploader: React.FC = () => {
     </Space>
   );
 };
+const BESdisabled = () => {
+  if (env.featureFlags?.browser) {
+    return <Navigate to="/browser" />;
+  }
+
+  if (env.featureFlags?.scheduler) {
+    return <Navigate to="/scheduler" />;
+  }
+
+  return <Navigate to="/operations" />;
+};
 
 export function HomePage() {
   return (
     <Space direction="vertical" size="large" className={styles.container}>
       {!!env.featureFlags?.home?.fileUpload && <BepFileUploader />}
       {!!env.featureFlags?.home?.instructions && <BuildInstructions />}
+      {!env.featureFlags?.home?.fileUpload &&
+        !env.featureFlags?.home?.instructions && <BESdisabled />}
     </Space>
   );
 }


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #294

When the configuration makes the home page empty, reroute to another page instead. The fall back priority is browser->scheduler->operations.