### PR TITLE
Remove all uses of `dataIndex`

### DIFF
--- a/frontend/src/components/FilesTable/Columns.tsx
+++ b/frontend/src/components/FilesTable/Columns.tsx
@@ -11,13 +11,13 @@ export interface FilesTableEntry {
 const modeColumn: ColumnType<FilesTableEntry> = {
   key: "mode",
   title: "Mode",
-  dataIndex: "mode",
+  render: (_, record) => record.mode,
 };
 
 const sizeColumn: ColumnType<FilesTableEntry> = {
   key: "size",
   title: "Size",
-  dataIndex: "size",
+  render: (_, record) => record.size,
 };
 
 const filenameColumn: ColumnType<FilesTableEntry> = {

--- a/frontend/src/components/OperationsGrid/Columns.tsx
+++ b/frontend/src/components/OperationsGrid/Columns.tsx
@@ -80,13 +80,14 @@ const actionDigestColumn: ColumnType<OperationState> = {
 };
 
 const targetIdColumn: ColumnType<OperationState> = {
+  key: "targetID",
   title: "Target ID",
-  dataIndex: "targetId",
+  render: (_, record) => record.targetId,
 };
 
 const statusColumn: ColumnType<OperationState> = {
-  title: "Status",
   key: "status",
+  title: "Status",
   render: (record: OperationState) => <OperationStatusTag operation={record} />,
 };
 

--- a/frontend/src/components/pages/BuildDetails/Columns.tsx
+++ b/frontend/src/components/pages/BuildDetails/Columns.tsx
@@ -121,7 +121,6 @@ export const getColumns = (): TableColumnTypeWithFilter<
     {
       key: "duration",
       title: "Duration",
-      dataIndex: "startedAt",
       render: (_, record) => (
         <PortalDuration
           key="duration"
@@ -138,7 +137,6 @@ export const getColumns = (): TableColumnTypeWithFilter<
     {
       key: "status",
       title: "Status",
-      dataIndex: "status",
       filterSearch: true,
       render: (_, record) => (
         <InvocationResultTag

--- a/frontend/src/components/pages/TestDetails/columns.tsx
+++ b/frontend/src/components/pages/TestDetails/columns.tsx
@@ -20,8 +20,8 @@ export const columns: TableColumnsType<TestDetailsRowType> = [
     render: (_, record) => <TestStatusTag status={record.overallStatus} />,
   },
   {
+    key: "invocationID",
     title: "Invocation ID",
-    dataIndex: "name",
     render: (_, record) => (
       <Link
         to="/bazel-invocations/$invocationID"
@@ -41,8 +41,8 @@ export const columns: TableColumnsType<TestDetailsRowType> = [
     ),
   },
   {
+    key: "duration",
     title: "Duration",
-    dataIndex: "duration",
     render: (_, record) => (
       <span className={styles.numberFormat}>
         {readableDurationFromMilliseconds(record.totalRunDurationInMs, {


### PR DESCRIPTION
Note: This is a stacked PR. Please merge #300

In Ant Design tables, you can either define a render function for a column, or the name of the field from which the column should get its data. The field name is configured with the field `dataIndex` and is a string. This string is not type checked at all. With this change we always use a render function, which gets us type safety.