### PR TITLE
Fix unpack on MacOS

### DIFF
--- a/internal/database/embedded/unpack.bzl
+++ b/internal/database/embedded/unpack.bzl
@@ -4,32 +4,23 @@ def _unpack_impl(ctx):
     input_tar = ctx.file.src
     output_dir = ctx.actions.declare_directory(ctx.attr.name + ".extracted")
     args = ctx.actions.args()
-    args.add_all([
-        ctx.file._xz.path,
-        ctx.file._tar.path,
-        input_tar.path,
-        output_dir.path,
-    ])
-    ctx.actions.run_shell(
-        inputs = [input_tar, ctx.file._xz, ctx.file._tar],
+    args.add("-I", ctx.executable._xz)
+    args.add("-xf", input_tar)
+    args.add("-C", output_dir.path)
+    ctx.actions.run(
+        executable = ctx.executable._tar,
+        inputs = [input_tar],
+        tools = [ctx.executable._xz],
         outputs = [output_dir],
         arguments = [args],
-        command = """
-        xz=$1
-        tar=$2
-        input=$3
-        output=$4
-        "$tar" -I "$xz" -xf "$input" -C "$output"
-        """
     )
     return [DefaultInfo(files = depset([output_dir]))]
-
 
 unpack = rule(
     implementation = _unpack_impl,
     attrs = {
         "src": attr.label(allow_single_file = True, mandatory = True),
-        "_tar": attr.label(default = "@ape//ape:tar", allow_single_file = True, executable = True, cfg = 'exec'),
-        "_xz": attr.label(default = "@ape//ape:xz", allow_single_file = True, executable = True, cfg = 'exec'),
+        "_tar": attr.label(default = "@ape//ape:tar", executable = True, cfg = "exec"),
+        "_xz": attr.label(default = "@ape//ape:xz", executable = True, cfg = "exec"),
     },
 )

--- a/internal/database/embedded/unpack.bzl
+++ b/internal/database/embedded/unpack.bzl
@@ -5,6 +5,7 @@ def _unpack_impl(ctx):
     output_dir = ctx.actions.declare_directory(ctx.attr.name + ".extracted")
     args = ctx.actions.args()
     args.add("-I", ctx.executable._xz)
+    args.add("--touch")
     args.add("-xf", input_tar)
     args.add("-C", output_dir.path)
     ctx.actions.run(


### PR DESCRIPTION
This PR addresses two issues with `unpack.bz` that were causing errors on MacOS:

(1) Private attributes `_xz` and `_tar` are accessed through `ctx.file`, which
requires `allow_single_file = True`. However, this restriction does not hold in
MacOS for `@ape//...` binaries.

(2) For some reasons (probably SIP), the `@ape//ape:tar` executable in MacOS is
not allowed to call `utime`.

For (1) the solution is to access executable targets appropriately: using
`ctx.executables` instead of `ctx.file` and relying on the `tools` argument of
`ctx.actions.run*` to ensure all runfiles are present. Additionally, while not
necessary to address (1), switching from `ctx.action.run_shell` to
`ctx.action.run` is a worthwhile improvement that removes `unpack`'s dependency
on a shell.

Regarding (2), it was enough to avoid dealing with `utime` completely via `-m`.
The only consequence of this is that extracted files do not preserve modified
time, which is not very relevant in our context.

Closes #304
