### PR TITLE
Prevent embedded PostgreSQL process leaks in tests

### DIFF
--- a/ent/authschema/privacy_test.go
+++ b/ent/authschema/privacy_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer dbProvider.Cleanup()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestPrivacy(t *testing.T) {

--- a/internal/database/buildeventrecorder/build_event_recorder_test.go
+++ b/internal/database/buildeventrecorder/build_event_recorder_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer dbProvider.Cleanup()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestFindOrCreateInstanceName(t *testing.T) {

--- a/internal/database/dbauthservice/dbauthservice_test.go
+++ b/internal/database/dbauthservice/dbauthservice_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer dbProvider.Cleanup()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestGetInstanceNames(t *testing.T) {

--- a/internal/database/dbcleanupservice/dbcleanupservice_test.go
+++ b/internal/database/dbcleanupservice/dbcleanupservice_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer dbProvider.Cleanup()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func getNewDbCleanupService(db database.Client, c clock.Clock, traceProvider trace.TracerProvider) (*dbcleanupservice.DbCleanupService, error) {

--- a/test/dbtest/dbindex_test.go
+++ b/test/dbtest/dbindex_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer dbProvider.Cleanup()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestDatabaseProperties(t *testing.T) {

--- a/test/integrationtest/util_test.go
+++ b/test/integrationtest/util_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	defer dbProvider.Cleanup()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func setupTestBepUploader(t *testing.T, db database.Client, testCase testCase) *bepuploader.BepUploader {


### PR DESCRIPTION
## Summary

  - Stop calling `os.Exit(m.Run())` from embedded-database `TestMain` implementations.
  - Allow `TestMain` to return normally so deferred `DatabaseProvider.Cleanup()` calls execute.
  - Preserve test exit statuses through the Go/Bazel test wrapper.

  ## Problem

  `os.Exit` terminates the process immediately without running deferred functions. This skipped embedded PostgreSQL cleanup and left orphaned processes after affected test binaries exited.

  ## Testing

  - Ran all six affected Bazel test targets successfully.
  - Forced an uncached `dbtest` execution and confirmed it did not leave a new embedded PostgreSQL process.