### PR TITLE
Fix crash on userinfo display

### DIFF
--- a/frontend/src/components/pages/UserDetails/flattenUserInfo.test.ts
+++ b/frontend/src/components/pages/UserDetails/flattenUserInfo.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "vitest";
+import { flattenUserInfo } from "./flattenUserInfo";
+
+test("flattenUserInfo", () => {
+  expect(flattenUserInfo({})).toEqual({});
+
+  expect(
+    flattenUserInfo({
+      foo: "bar",
+      baz: 1,
+      nested: {
+        object: "hello",
+      },
+    }),
+  ).toEqual({
+    foo: "bar",
+    baz: "1",
+    "nested/object": "hello",
+  });
+});

--- a/frontend/src/components/pages/UserDetails/flattenUserInfo.ts
+++ b/frontend/src/components/pages/UserDetails/flattenUserInfo.ts
@@ -1,0 +1,23 @@
+function flattenObject(
+  obj: unknown,
+  path: string,
+  out: Record<string, string>,
+) {
+  if (obj === null || obj === undefined) {
+    out[path] = "?";
+  } else if (typeof obj === "object") {
+    const record = obj as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      const newPath = path ? `${path}/${key}` : key;
+      flattenObject(record[key], newPath, out);
+    }
+  } else {
+    out[path] = String(obj);
+  }
+}
+
+export function flattenUserInfo(obj: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  flattenObject(obj, "", out);
+  return out;
+}

--- a/frontend/src/components/pages/UserDetails/index.tsx
+++ b/frontend/src/components/pages/UserDetails/index.tsx
@@ -21,6 +21,7 @@ import type {
 } from "@/graphql/__generated__/graphql";
 import themeStyles from "@/theme/theme.module.css";
 import { parseGraphqlEdgeList } from "@/utils/parseGraphqlEdgeList";
+import { flattenUserInfo } from "./flattenUserInfo";
 
 interface Props {
   pageSize: number | undefined;
@@ -36,7 +37,7 @@ export const UserDetailsPage: React.FC<Props> = ({
   getPaginationUpdateLink,
 }) => {
   const invocations = parseGraphqlEdgeList(user.bazelInvocations);
-  const userInfo = user.userInfo || {};
+  const userInfo = flattenUserInfo(user.userInfo);
 
   const tableColumns = [
     invocationIdColumn,


### PR DESCRIPTION
The frontend expects the UserInfo to be a object with string values, but the backend can send nested objects as well. This change makes sure that the frontend can handle nested objects by flattening the objects and displaying them as strings first.