### PR TITLE
Make Biome error out on warnings

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTUzNjQ2NjY3
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTUzNjQ2NjY3
@@ -2,6 +2,6 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "@@//frontend:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 frontend/package-lock.json=-1493141742
-frontend/package.json=1393032116
+frontend/package.json=867342644
 frontend/patches/vite.patch=-1261363333
 frontend/pnpm-lock.yaml=-1152862257

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,9 @@
     "generate-possible-types": "node ./tools/create-possible-types.js",
     "predev": "npm run generate",
     "format": "biome format --write",
-    "lint": "biome lint --write",
-    "check": "biome check --write",
-    "biome-ci": "biome ci",
+    "lint": "biome lint --write --error-on-warnings",
+    "check": "biome check --write --error-on-warnings",
+    "biome-ci": "biome ci --error-on-warnings",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
This makes sure that CI catches any warnings emitted by Biome. A warning is considered severe enough to warrant at least a disabling comment.