### PR TITLE
Run cleanup at fixed intervals instead of delays

### DIFF
--- a/internal/database/dbcleanupservice/dbcleanupservice.go
+++ b/internal/database/dbcleanupservice/dbcleanupservice.go
@@ -75,13 +75,21 @@ func (dc *DbCleanupService) StartDbCleanupService(ctx context.Context, group pro
 		ctx = dbauthservice.NewContextWithDbAuthServiceBypass(ctx)
 		for {
 			dc.counter++
-			// Add 5% jitter to the cleanup interval
-			timeToSleep := dc.cleanupInterval + time.Duration((rand.Float64()*0.1-0.05)*float64(dc.cleanupInterval))
+			startTime := dc.clock.Now()
+
+			dc.performCleanup(ctx)
+
+			// Add 5% jitter to the target interval
+			jitter := time.Duration((rand.Float64()*0.1 - 0.05) * float64(dc.cleanupInterval))
+			targetInterval := dc.cleanupInterval + jitter
+
+			elapsed := dc.clock.Now().Sub(startTime)
+			timeToSleep := max(targetInterval-elapsed, 0)
+
 			select {
 			case <-ctx.Done():
 				return nil
 			case <-time.After(timeToSleep):
-				dc.performCleanup(ctx)
 			}
 		}
 	})


### PR DESCRIPTION
Previously, the cleanup process slept for a static duration after each run, causing the schedule to drift. We now calculate the elapsed execution time and adjust the sleep window so that cleanup triggers at the configured interval.