### PR TITLE
Fix Tanstack router chunking issue on local build

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     tanstackRouter({
       target: "react",
       autoCodeSplitting: true,
+      routesDirectory: path.resolve(__dirname, "./src/routes"),
     }),
     react(),
     babel({ presets: [reactCompilerPreset({ target: "19" })] }),


### PR DESCRIPTION
Tanstack uses the current working directory to generate the route tree. It receives the expected id and current id (where id is file id of each route) through the transform hook in order to generate a chunk. Tanstack router's expected id resides in cwd. Since vite manages symlinks itself, its File IDs are not in the same repo as the cwd. This results in a mismatch which causes no chunks to be created. This doesn't happen with remote execution.

Without remote execution:
File ID (Vite): /../execroot/_main/bazel-out/k8-opt-exec/bin/frontend/src/routeTree.gen.ts process.cwd(): /../sandbox/linux-sandbox/8/execroot/_main/bazel-out/k8-opt-exec/bin/frontend __dirname: /../execroot/_main/bazel-out/k8-opt-exec/bin/frontend

With remote execution:
File ID (Vite): /../ubuntu-24-04-opt-exec/bin/frontend/src/routeTree.gen.ts process.cwd(): ../ubuntu-24-04-opt-exec/bin/frontend __dirname: /../ubuntu-24-04-opt-exec/bin/frontend

The correct directory is now passed to the Tanstack plugin which fixes this issue.