### PR TITLE
Add log viewer search bar

### DIFF
--- a/frontend/src/components/LogViewer/ansiScrollWindow.tsx
+++ b/frontend/src/components/LogViewer/ansiScrollWindow.tsx
@@ -1,29 +1,37 @@
-import { AnsiUp } from "ansi_up";
-import React, { useEffect, useRef } from "react";
+import type React from "react";
+import { useEffect, useRef } from "react";
 import { experimental_VGrid as VGrid, type VGridHandle } from "virtua";
 import PortalAlert from "../PortalAlert";
 import styles from "./index.module.css";
-
-const ansi = new AnsiUp();
+import { LogRow } from "./logRow";
 
 interface Props {
-  log: string;
+  log: string[];
+  query: string;
+  matchIndexList: number[];
+  currentMatchIndex: number;
 }
 
 // Takes a log in ansi style, formats it to HTML, and displays it in a scrollable window with virtualization
-const AnsiScrollingWindow: React.FC<Props> = ({ log }) => {
-  const lines = React.useMemo(() => {
-    if (!log) return [];
-    return ansi.ansi_to_html(log).split("\n");
-  }, [log]);
-
+const AnsiScrollingWindow: React.FC<Props> = ({
+  log,
+  query,
+  matchIndexList,
+  currentMatchIndex,
+}) => {
   const vListRef = useRef<VGridHandle>(null);
 
   useEffect(() => {
+    if (!matchIndexList.length) return;
+    const rowIndex = matchIndexList[currentMatchIndex];
+    vListRef.current?.scrollToIndex?.(rowIndex);
+  }, [matchIndexList, currentMatchIndex]);
+
+  useEffect(() => {
     if (vListRef.current) {
-      vListRef.current.scrollToIndex(lines.length - 1);
+      vListRef.current.scrollToIndex(log.length - 1);
     }
-  }, [lines]);
+  }, [log]);
 
   if (!log) {
     return (
@@ -35,24 +43,10 @@ const AnsiScrollingWindow: React.FC<Props> = ({ log }) => {
       />
     );
   }
+
   const LINE_HEIGHT = 16.66; // 14px base font size * 0.85 font-size * 1.4 line-height
   const PADDING_HEIGHT = 14; // (Vertical padding + border) * 2
-  const MAX_VISIBLE_LINES = 27.3; // Make the top line only partially visible to convey that the view screen is scrollable
-  if (lines.length < MAX_VISIBLE_LINES) {
-    return (
-      <pre className={styles.scrollWindow}>
-        {lines.map((v, i) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: We have nothing better to use
-            key={i}
-            // TODO: Remove the danger
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: Should be reworked
-            dangerouslySetInnerHTML={{ __html: v }}
-          />
-        ))}
-      </pre>
-    );
-  }
+  const MAX_VISIBLE_LINES = Math.min(27.3, log.length); // Make the top line only partially visible to convey that the view screen is scrollable
   return (
     <pre>
       <VGrid
@@ -61,18 +55,18 @@ const AnsiScrollingWindow: React.FC<Props> = ({ log }) => {
           height: MAX_VISIBLE_LINES * LINE_HEIGHT + PADDING_HEIGHT,
         }}
         className={styles.scrollWindow}
-        row={lines.length}
+        row={log.length}
         col={1}
         cellHeight={LINE_HEIGHT}
       >
         {({ rowIndex }) => (
-          <span
-            // This is also using an index as key, but biome dosn't notice.
+          <LogRow
             key={rowIndex}
-            // TODO: Remove the danger
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: Should be reworked
-            dangerouslySetInnerHTML={{ __html: lines[rowIndex] }}
-          />
+            query={query}
+            rowIndex={rowIndex}
+            line={log[rowIndex]}
+            matchIndexList={matchIndexList}
+          ></LogRow>
         )}
       </VGrid>
     </pre>

--- a/frontend/src/components/LogViewer/index.tsx
+++ b/frontend/src/components/LogViewer/index.tsx
@@ -5,13 +5,14 @@ import {
 } from "@ant-design/icons";
 import { Button, Spin, Tooltip } from "antd";
 import type React from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import PortalAlert from "@/components/PortalAlert";
 import { useBbPortalMessage } from "@/context/MessageContext";
 import { readableFileSize } from "@/utils/filesize";
 import PortalCard from "../PortalCard";
 import { AnsiScrollingWindow } from "./ansiScrollWindow";
 import styles from "./index.module.css";
+import { SearchBar } from "./searchbar";
 
 export const SIZE_BYTE_LIMIT = 1_000_000; // 1MB
 
@@ -41,6 +42,14 @@ export const LogViewerCard: React.FC<Props> = ({
 
   const historicalExecuteResponseUrl = useMemo(() => {
     return log?.match(HISTORICAL_EXECUTE_RESPONSE_REGEX)?.[0];
+  }, [log]);
+
+  const [query, setQuery] = useState("");
+  const [matchIndexList, setMatchIndexList] = useState<number[]>([]);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const logList = useMemo(() => {
+    if (!log) return [];
+    return log.split("\n");
   }, [log]);
 
   const renderContent = useMemo(() => {
@@ -83,8 +92,24 @@ export const LogViewerCard: React.FC<Props> = ({
         />
       );
     }
-    return <AnsiScrollingWindow log={log} />;
-  }, [loading, error, logSizeBytes, log]);
+    return (
+      <AnsiScrollingWindow
+        log={logList}
+        query={query}
+        matchIndexList={matchIndexList}
+        currentMatchIndex={currentMatchIndex}
+      />
+    );
+  }, [
+    loading,
+    error,
+    logSizeBytes,
+    log,
+    query,
+    matchIndexList,
+    currentMatchIndex,
+    logList,
+  ]);
 
   return (
     <PortalCard
@@ -98,6 +123,17 @@ export const LogViewerCard: React.FC<Props> = ({
         </div>,
       ]}
       extraBits={[
+        <div key={"search bar"}>
+          <SearchBar
+            query={query}
+            setQuery={setQuery}
+            matchIndexList={matchIndexList}
+            currentMatchIndex={currentMatchIndex}
+            setCurrentMatchIndex={setCurrentMatchIndex}
+            items={logList}
+            setMatchIndexList={setMatchIndexList}
+          />
+        </div>,
         historicalExecuteResponseUrl && (
           <Tooltip
             key="historical-url"

--- a/frontend/src/components/LogViewer/logRow.tsx
+++ b/frontend/src/components/LogViewer/logRow.tsx
@@ -1,0 +1,52 @@
+import { AnsiUp } from "ansi_up";
+import {
+  ANSI_HIGHLIGHT_START,
+  ANSI_RESET,
+  ansiRegex,
+  escapeRegex,
+} from "./utils";
+export interface Props {
+  query: string;
+  rowIndex: number;
+  line: string;
+  matchIndexList: number[];
+}
+const ansi = new AnsiUp();
+
+function highlightLine(line: string, query: string): string {
+  return line
+    .replace(ansiRegex(), "")
+    .replace(
+      escapeRegex(query),
+      (match) => `${ANSI_HIGHLIGHT_START}${match}${ANSI_RESET}`,
+    );
+}
+
+const renderLine = (
+  query: string,
+  rowIndex: number,
+  line: string,
+  matchIndexList: number[],
+) => {
+  const matchSet = new Set(matchIndexList);
+  if (!query) return ansi.ansi_to_html(line);
+  return matchSet.has(rowIndex)
+    ? ansi.ansi_to_html(highlightLine(line, query))
+    : ansi.ansi_to_html(line);
+};
+
+export const LogRow: React.FC<Props> = ({
+  query,
+  rowIndex,
+  line,
+  matchIndexList,
+}) => {
+  return (
+    <span
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: Should be reworked
+      dangerouslySetInnerHTML={{
+        __html: renderLine(query, rowIndex, line, matchIndexList),
+      }}
+    />
+  );
+};

--- a/frontend/src/components/LogViewer/searchbar.tsx
+++ b/frontend/src/components/LogViewer/searchbar.tsx
@@ -1,0 +1,109 @@
+import { Input } from "antd";
+import { useCallback, useEffect, useMemo } from "react";
+import { ansiRegex, escapeRegex } from "./utils";
+
+export interface SearchBarProps {
+  query: string;
+  setQuery: React.Dispatch<React.SetStateAction<string>>;
+  matchIndexList: number[];
+  setMatchIndexList: React.Dispatch<React.SetStateAction<number[]>>;
+  currentMatchIndex: number;
+  setCurrentMatchIndex: React.Dispatch<React.SetStateAction<number>>;
+  items: string[];
+}
+
+export const SearchBar = ({
+  query,
+  setQuery,
+  matchIndexList,
+  setMatchIndexList,
+  currentMatchIndex,
+  setCurrentMatchIndex,
+  items,
+}: SearchBarProps) => {
+  const matchLimit = 10000;
+  const foundMatches = useMemo(() => {
+    const result: number[] = [];
+    let totalMatches = 0;
+    const escapedQuery = escapeRegex(query);
+
+    // Match all occurrences of the query and store their indices
+    for (let i = 0; i < items.length; i++) {
+      const cleanItem = items[i].replace(ansiRegex(), "");
+
+      for (const _ of cleanItem.matchAll(escapedQuery)) {
+        result.push(i);
+        totalMatches++;
+
+        if (totalMatches >= matchLimit) {
+          return result;
+        }
+      }
+    }
+
+    return result;
+  }, [query, items]);
+
+  const nextMatch = useCallback(() => {
+    setCurrentMatchIndex((i) =>
+      matchIndexList.length ? (i + 1) % matchIndexList.length : 0,
+    );
+  }, [setCurrentMatchIndex, matchIndexList.length]);
+
+  const prevMatch = useCallback(() => {
+    setCurrentMatchIndex((i) => {
+      if (!matchIndexList.length) return -1;
+
+      return (i - 1 + matchIndexList.length) % matchIndexList.length;
+    });
+  }, [matchIndexList.length, setCurrentMatchIndex]);
+
+  // Prevent default behavior of F3 outisde searchfield focus
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "F3" && event.shiftKey) {
+        event.preventDefault();
+        prevMatch();
+      } else if (event.key === "F3") {
+        event.preventDefault();
+        nextMatch();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [nextMatch, prevMatch]);
+
+  useEffect(() => {
+    setMatchIndexList(foundMatches);
+    setCurrentMatchIndex(0);
+  }, [foundMatches, setCurrentMatchIndex, setMatchIndexList]);
+
+  return (
+    <Input.Search
+      placeholder="Search"
+      onSearch={() => nextMatch()}
+      onChange={(e) => setQuery(e.target.value)}
+      value={query}
+      suffix={
+        <span
+          style={{
+            display: "inline-block",
+            minWidth: "45px",
+            textAlign: "right",
+            fontSize: "12px",
+          }}
+        >
+          {query.length > 0
+            ? foundMatches.length < matchLimit
+              ? `${matchIndexList.length > 0 ? currentMatchIndex + 1 : 0} / ${matchIndexList.length}`
+              : `${currentMatchIndex + 1} / ${matchLimit}+`
+            : null}
+        </span>
+      }
+    />
+  );
+};

--- a/frontend/src/components/LogViewer/utils.ts
+++ b/frontend/src/components/LogViewer/utils.ts
@@ -1,0 +1,25 @@
+// Escape regex special characters to treat query as plain text.
+// Examples:
+// "a+b"   -> "a\+b"       (prevents + from meaning one or more)
+// "file.*" -> "file\.\*"  (prevents .* from matching any characters)
+// "a|b"    -> "a\|b"      (prevents | from acting as an OR operator)
+// export const escapedQuery = (query: string) => {
+//   return query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+// };
+export const escapeRegex = (query: string) => {
+  const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(escapedQuery, "gi");
+};
+
+// Regex for ANSI escape codes (colors, formatting, etc)
+// Example: "\x1B[31mError\x1B[0m" ignores the color codes
+export const ansiRegex = () => {
+  const ansiPattern = "\\x1B\\[[0-9;]*m";
+  return new RegExp(ansiPattern, "g");
+};
+
+// ANSI escape codes for highlighting
+export const ANSI_HIGHLIGHT_START = "\x1B[30;103m";
+
+// ANSI escape code for resetting formatting
+export const ANSI_RESET = "\x1B[0m";


### PR DESCRIPTION
Add a search bar to the log viewer, allowing the user to search in the logs. Just using the browsers search doesn't work since the log viewer uses virtualization to not render the entire log at once.

- The matched characters are highlighted
- Shortcut keys like F3, enter, esc, backspace+F3 can be used