### PR TITLE
Only initialize side menu when it is needed

### DIFF
--- a/frontend/src/components/AppBar/index.tsx
+++ b/frontend/src/components/AppBar/index.tsx
@@ -108,22 +108,24 @@ const AppBar: React.FC<Props> = ({ toggleTheme, prefersDark }) => {
           </Button>
         )}
       </Layout.Header>
-      <Drawer
-        placement="right"
-        closable={true}
-        onClose={() => {
-          setIsDrawerOpen(false);
-        }}
-        onClick={() => {
-          setIsDrawerOpen(false);
-        }}
-        open={isDrawerOpen}
-        footer={<FooterBar className={styles.footerBar} />}
-      >
-        <AppBarMenu mode="inline" items={APP_BAR_MENU_ITEMS} />
-        <Divider orientation="center" type="horizontal" />
-        <AppBarButtons toggleTheme={toggleTheme} prefersDark={prefersDark} />
-      </Drawer>
+      {!showHeaderMenu && (
+        <Drawer
+          placement="right"
+          closable={true}
+          onClose={() => {
+            setIsDrawerOpen(false);
+          }}
+          onClick={() => {
+            setIsDrawerOpen(false);
+          }}
+          open={isDrawerOpen}
+          footer={<FooterBar className={styles.footerBar} />}
+        >
+          <AppBarMenu mode="inline" items={APP_BAR_MENU_ITEMS} />
+          <Divider orientation="center" type="horizontal" />
+          <AppBarButtons toggleTheme={toggleTheme} prefersDark={prefersDark} />
+        </Drawer>
+      )}
     </>
   );
 };


### PR DESCRIPTION
The side menu can only be shown when the width is small enough, but the component was always initialized and in the DOM even if it was not needed. This makes sure we don't create it if we don't need it.