### PR TITLE
Fix concurrent target imports

### DIFF
--- a/internal/database/buildeventrecorder/BUILD.bazel
+++ b/internal/database/buildeventrecorder/BUILD.bazel
@@ -75,8 +75,10 @@ go_test(
     deps = [
         ":buildeventrecorder",
         "//ent/gen/ent/runtime",
+        "//internal/database",
         "//internal/database/dbauthservice",
         "//internal/database/embedded",
+        "//internal/database/sqlc",
         "//test/testutils",
         "@com_github_google_uuid//:uuid",
         "@com_github_prometheus_client_golang//prometheus",

--- a/internal/database/buildeventrecorder/build_event_recorder_test.go
+++ b/internal/database/buildeventrecorder/build_event_recorder_test.go
@@ -2,13 +2,17 @@ package buildeventrecorder_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/buildbarn/bb-portal/internal/database"
 	"github.com/buildbarn/bb-portal/internal/database/buildeventrecorder"
 	"github.com/buildbarn/bb-portal/internal/database/dbauthservice"
 	"github.com/buildbarn/bb-portal/internal/database/embedded"
+	"github.com/buildbarn/bb-portal/internal/database/sqlc"
 	"github.com/buildbarn/bb-portal/test/testutils"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -96,4 +100,117 @@ func TestFindOrCreateInvocation(t *testing.T) {
 		require.Equal(t, codes.FailedPrecondition, st.Code())
 		require.Contains(t, err.Error(), "locked for writing")
 	})
+}
+
+func TestCreateTargetsConcurrently(t *testing.T) {
+	ctx, db, instanceNameID := setupTargetTestDB(t)
+	params := sqlc.CreateTargetsParams{
+		InstanceNameID: instanceNameID,
+		Labels:         []string{"//example:target"},
+		Aspects:        []string{""},
+		TargetKinds:    []string{"example_rule"},
+	}
+
+	type result struct {
+		rows []sqlc.CreateTargetsRow
+		err  error
+	}
+	const importCount = 6
+	start := make(chan struct{})
+	results := make(chan result, importCount)
+	for range importCount {
+		go func() {
+			<-start
+			rows, err := db.Sqlc().CreateTargets(ctx, params)
+			results <- result{rows: rows, err: err}
+		}()
+	}
+	close(start)
+
+	var targetID int64
+	createdCount := 0
+	for range importCount {
+		result := <-results
+		require.NoError(t, result.err)
+		require.LessOrEqual(t, len(result.rows), 1)
+		if len(result.rows) == 1 {
+			createdCount++
+			targetID = result.rows[0].ID
+		}
+	}
+	require.Equal(t, 1, createdCount)
+
+	foundRows, err := db.Sqlc().FindTargets(ctx, sqlc.FindTargetsParams{
+		InstanceNameID: instanceNameID,
+		Labels:         params.Labels,
+		Aspects:        params.Aspects,
+		TargetKinds:    params.TargetKinds,
+	})
+	require.NoError(t, err)
+	require.Len(t, foundRows, 1)
+	require.Equal(t, targetID, foundRows[0].ID)
+
+	targetCount, err := db.Ent().Target.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, targetCount)
+}
+
+func TestCreateTargetsDoesNotBlockInvocationTargetForeignKey(t *testing.T) {
+	ctx, db, instanceNameID := setupTargetTestDB(t)
+	params := sqlc.CreateTargetsParams{
+		InstanceNameID: instanceNameID,
+		Labels:         []string{"//example:target"},
+		Aspects:        []string{""},
+		TargetKinds:    []string{"example_rule"},
+	}
+	createdRows, err := db.Sqlc().CreateTargets(ctx, params)
+	require.NoError(t, err)
+	require.Len(t, createdRows, 1)
+
+	instanceName, err := db.Ent().InstanceName.Get(ctx, instanceNameID)
+	require.NoError(t, err)
+	invocation, err := testutils.StartCreateInvocation(db.Ent(), instanceName).Save(ctx)
+	require.NoError(t, err)
+	const configurationID = "config"
+	_, err = db.Ent().Configuration.Create().
+		SetConfigurationID(configurationID).
+		SetBazelInvocation(invocation).
+		Save(ctx)
+	require.NoError(t, err)
+
+	targetTx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = targetTx.Rollback() })
+	conflictingRows, err := targetTx.Sqlc().CreateTargets(ctx, params)
+	require.NoError(t, err)
+	require.Empty(t, conflictingRows)
+
+	insertCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	err = db.Sqlc().CreateInvocationTargetsBulk(insertCtx, sqlc.CreateInvocationTargetsBulkParams{
+		BazelInvocationID: invocation.ID,
+		TargetIds:         []int64{createdRows[0].ID},
+		ConfigurationIds:  []string{configurationID},
+		Successes:         []bool{true},
+		TagsList:          []string{""},
+		FailureMessages:   []string{""},
+		AbortReasons:      []string{"NONE"},
+	})
+	require.NoError(t, err)
+}
+
+func setupTargetTestDB(t *testing.T) (context.Context, database.Client, int64) {
+	t.Helper()
+	ctx := dbauthservice.NewContextWithDbAuthServiceBypass(context.Background())
+	connection, err := dbProvider.CreateDatabase()
+	require.NoError(t, err)
+	connection.SetMaxOpenConns(6)
+	t.Cleanup(func() { require.NoError(t, connection.Close()) })
+
+	db, err := database.New("postgres", connection)
+	require.NoError(t, err)
+	require.NoError(t, db.Ent().Schema.Create(ctx))
+	instanceNameID, err := buildeventrecorder.FindOrCreateInstanceName(ctx, db, "testInstance")
+	require.NoError(t, err)
+	return ctx, db, instanceNameID
 }

--- a/internal/database/buildeventrecorder/save_target_configured.go
+++ b/internal/database/buildeventrecorder/save_target_configured.go
@@ -158,6 +158,25 @@ func getOrCreateTargets(ctx context.Context, instanceNameID int64, tx database.H
 		result[targetKey{label: row.Label, aspect: row.Aspect, kind: row.TargetKind}] = int(row.ID)
 	}
 	if len(result) != len(uniqueKeys) {
+		// ON CONFLICT DO NOTHING does not return targets inserted by another
+		// transaction. The insert waits for those transactions to finish, so a
+		// new READ COMMITTED snapshot can now retrieve their IDs without taking
+		// update locks on the target rows.
+		missLabels, missAspects, missKinds = findMissingRows(labels, aspects, kinds, result)
+		concurrentRows, err := tx.Sqlc().FindTargets(ctx, sqlc.FindTargetsParams{
+			InstanceNameID: int64(instanceNameID),
+			Labels:         missLabels,
+			Aspects:        missAspects,
+			TargetKinds:    missKinds,
+		})
+		if err != nil {
+			return nil, util.StatusWrap(err, "Failed to find targets inserted concurrently")
+		}
+		for _, row := range concurrentRows {
+			result[targetKey{label: row.Label, aspect: row.Aspect, kind: row.TargetKind}] = int(row.ID)
+		}
+	}
+	if len(result) != len(uniqueKeys) {
 		return nil, status.Error(codes.Unavailable, "Not all missing targets were created.")
 	}
 	return result, nil

--- a/internal/database/sqlc/querier.go
+++ b/internal/database/sqlc/querier.go
@@ -36,6 +36,9 @@ type Querier interface {
 	//   2. Explicitly collate to normalize sort order between database
 	// instantiations, otherwise golden file generation may have a different
 	// order than what's used during the test.
+	// Concurrent invocations may both observe the target as missing. Do not update
+	// the existing row: that would conflict with foreign-key locks held by batches
+	// which are already creating invocation targets for it.
 	CreateTargets(ctx context.Context, arg CreateTargetsParams) ([]CreateTargetsRow, error)
 	CreateTestActionOutputAssociation(ctx context.Context, arg CreateTestActionOutputAssociationParams) (int64, error)
 	// STAGE 2: Join the rest using the specific Target IDs we found

--- a/internal/database/sqlc/targets.sql.go
+++ b/internal/database/sqlc/targets.sql.go
@@ -26,6 +26,8 @@ ORDER BY
     label COLLATE "C",
     aspect COLLATE "C",
     target_kind COLLATE "C"
+ON CONFLICT (label, aspect, target_kind, instance_name_targets)
+DO NOTHING
 RETURNING id, label, aspect, target_kind
 `
 
@@ -51,6 +53,9 @@ type CreateTargetsRow struct {
 //
 // instantiations, otherwise golden file generation may have a different
 // order than what's used during the test.
+// Concurrent invocations may both observe the target as missing. Do not update
+// the existing row: that would conflict with foreign-key locks held by batches
+// which are already creating invocation targets for it.
 func (q *Queries) CreateTargets(ctx context.Context, arg CreateTargetsParams) ([]CreateTargetsRow, error) {
 	rows, err := q.db.QueryContext(ctx, createTargets,
 		arg.InstanceNameID,

--- a/sql/queries/targets.sql
+++ b/sql/queries/targets.sql
@@ -34,6 +34,11 @@ ORDER BY
     label COLLATE "C",
     aspect COLLATE "C",
     target_kind COLLATE "C"
+-- Concurrent invocations may both observe the target as missing. Do not update
+-- the existing row: that would conflict with foreign-key locks held by batches
+-- which are already creating invocation targets for it.
+ON CONFLICT (label, aspect, target_kind, instance_name_targets)
+DO NOTHING
 RETURNING id, label, aspect, target_kind;
 
 -- name: DeleteUnusedTargetsFromPages :execrows


### PR DESCRIPTION
This address an issue when uploading multiple invocations at once and those multiple invocations contains the same targets, all those common invocations will conflict when trying to insert the same target