### PR TITLE
Add the vitest_test macro to the Bazel rules.

### DIFF
--- a/frontend/BUILD.bazel
+++ b/frontend/BUILD.bazel
@@ -2,7 +2,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//frontend:vite/package_json.bzl", vite_bin = "bin")
 load("//tools:protobuf.bzl", "get_proto_src")
-load(":vite.bzl", "vite_build")
+load(":vite.bzl", "vite_build", "vitest_test")
 
 PROTO_FILES = {
     "bazel_remote_execution": ("remote_execution", "build/bazel/remote/execution/v2", "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_proto"),
@@ -69,22 +69,30 @@ vite_bin.vite_binary(
     name = "vite_binary",
 )
 
+FRONTEND_SRCS = glob(
+    [
+        "src/**",
+        "public/**",
+    ],
+    allow_empty = True,
+    exclude = ["node_modules/**"],
+) + [
+    "index.html",
+    "package.json",
+    "tsconfig.json",
+    "vite.config.ts",
+    ":node_modules",
+]
+
 vite_build(
     name = "dist",
-    srcs = glob(
-        [
-            "src/**",
-            "public/**",
-        ],
-        allow_empty = True,
-        exclude = ["node_modules/**"],
-    ) + [
-        "index.html",
-        "package.json",
-        "tsconfig.json",
-        "vite.config.ts",
-        ":node_modules",
-    ],
+    srcs = FRONTEND_SRCS,
     visibility = ["//visibility:public"],
     vite_binary = ":vite_binary",
+)
+
+vitest_test(
+    name = "vitest_test",
+    size = "small",
+    srcs = FRONTEND_SRCS,
 )

--- a/frontend/vite.bzl
+++ b/frontend/vite.bzl
@@ -1,4 +1,5 @@
 load("@bazel_lib//lib:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")
+load("@npm//frontend:vitest/package_json.bzl", _vitest_bin = "bin")
 
 def _vite_build_rule_impl(ctx):
     out_dir = ctx.actions.declare_directory(ctx.label.name)
@@ -49,7 +50,7 @@ def _vite_build_macro_impl(name, srcs, tags, **kwargs):
         name = name,
         srcs = [":{}".format(copy_to_bin_name)],
         tags = tags,
-        **kwargs,
+        **kwargs
     )
 
 vite_build = macro(
@@ -57,3 +58,27 @@ vite_build = macro(
     implementation = _vite_build_macro_impl,
     inherit_attrs = vite_build_rule,
 )
+
+def vitest_test(name, srcs, args = ["run"], **kwargs):
+    """Runs the project's vitest test suite under Bazel.
+
+    Args:
+        name: name of the test target.
+        srcs: source files needed at test time: the test files themselves,
+            the code under test, and vitest's configuration (vite.config.ts,
+            tsconfig.json, package.json, node_modules).
+        args: CLI args passed to `vitest`. Defaults to `["run"]` so the suite
+            runs once and exits, instead of vitest's default watch mode.
+        **kwargs: additional args forwarded to the underlying js_test rule,
+            e.g. size or tags.
+    """
+    _vitest_bin.vitest_test(
+        name = name,
+        data = srcs,
+        args = args,
+        # Run inside this directory (relative to the workspace root) so that
+        # vitest picks up frontend/vite.config.ts and resolves the "@/" alias
+        # and node_modules the same way `npm run test` does.
+        chdir = native.package_name(),
+        **kwargs
+    )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -50,6 +50,14 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+    // Under Bazel, test/source files are exposed to the process via a
+    // runfiles symlink tree. Vite's dev-server-style module graph (used by
+    // vitest) follows symlinks to their real path by default, which resolves
+    // outside that tree and isn't visible to the sandbox running the test.
+    // Scoped to `vitest` (which sets process.env.VITEST) since enabling this
+    // for `vite build` breaks Rolldown's resolution of pnpm's nested,
+    // symlinked transitive dependencies.
+    preserveSymlinks: !!process.env.VITEST,
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
Vitest is a testing framework for vite applications. This is distributed with the NPM rules. This code exposes the vite testing framework for the Portal. This allows running the frontend vite framework tests as part of the larger bazel testing.

This has been extracted from, and needs to be merged before #337