### PR TITLE
Support more invocation exit codes

### DIFF
--- a/frontend/src/components/InvocationResultTag/enum.ts
+++ b/frontend/src/components/InvocationResultTag/enum.ts
@@ -9,6 +9,9 @@ export enum InvocationResult {
   NOT_BUILT = "NOT_BUILT",
   ABORTED = "ABORTED",
   INTERRUPTED = "INTERRUPTED",
+  ANALYSIS_FAILURE = "ANALYSIS_FAILURE",
+  COMMAND_LINE_ERROR = "COMMAND_LINE_ERROR",
+
   // Custom statuses
   UNKNOWN_EXIT_CODE = "UNKNOWN_EXIT_CODE",
   IN_PROGRESS = "IN_PROGRESS",
@@ -25,6 +28,8 @@ export const InvocationExitCodes = [
   InvocationResult.NOT_BUILT.toString(),
   InvocationResult.ABORTED.toString(),
   InvocationResult.INTERRUPTED.toString(),
+  InvocationResult.ANALYSIS_FAILURE.toString(),
+  InvocationResult.COMMAND_LINE_ERROR.toString(),
 ];
 
 export const INVOCATION_IN_PROGRESS_TIMEOUT = 12 * 1000;

--- a/frontend/src/components/InvocationResultTag/filters.ts
+++ b/frontend/src/components/InvocationResultTag/filters.ts
@@ -16,6 +16,8 @@ export const invocationResultTagFilters = [
   { text: "Not Built", value: InvocationResult.NOT_BUILT },
   { text: "Aborted", value: InvocationResult.ABORTED },
   { text: "Interrupted", value: InvocationResult.INTERRUPTED },
+  { text: "Analysis Failure", value: InvocationResult.ANALYSIS_FAILURE },
+  { text: "Command Line Error", value: InvocationResult.COMMAND_LINE_ERROR },
   { text: "Unknown exit code", value: InvocationResult.UNKNOWN_EXIT_CODE },
   { text: "In Progress", value: InvocationResult.IN_PROGRESS },
   { text: "Disconnected", value: InvocationResult.DISCONNECTED },

--- a/frontend/src/components/InvocationResultTag/index.tsx
+++ b/frontend/src/components/InvocationResultTag/index.tsx
@@ -65,6 +65,16 @@ export const INVOCATION_RESULT_TAGS: {
     color: "cyan",
     text: "Interrupted",
   },
+  ANALYSIS_FAILURE: {
+    icon: <CloseCircleFilled />,
+    color: "red",
+    text: "Analysis Failure",
+  },
+  COMMAND_LINE_ERROR: {
+    icon: <CloseCircleFilled />,
+    color: "red",
+    text: "Command Line Error",
+  },
   UNKNOWN_EXIT_CODE: {
     icon: <QuestionCircleFilled />,
     color: "default",


### PR DESCRIPTION
Add visualization support for `ANALYSIS_FAILURE` and `COMMAND_LINE_ERROR` exit codes.